### PR TITLE
DB設計に合わせてスキーマを更新

### DIFF
--- a/web-app/app/db/schema.ts
+++ b/web-app/app/db/schema.ts
@@ -2,10 +2,8 @@ import {
 	boolean,
 	date,
 	integer,
-	pgEnum,
 	pgTable,
 	text,
-	time,
 	timestamp,
 	unique,
 	uuid,
@@ -114,11 +112,10 @@ export const habit = pgTable("habit", {
 		.notNull()
 		.references(() => user.id, { onDelete: "cascade" }),
 	name: text("name").notNull(),
-	emoji: text("emoji").notNull(),
-	deadTime: time("deadTime").notNull(), // 'HH:mm:ss'
+	emoji: text("emoji").notNull().default(""),
 	currentStreak: integer("currentStreak").notNull().default(0),
 	maxStreak: integer("maxStreak").notNull().default(0),
-	isArchived: boolean("isArchived").notNull().default(false),
+	archivedAt: timestamp("archivedAt", { mode: "date", withTimezone: true }),
 	createdAt: timestamp("createdAt", { mode: "date", withTimezone: true })
 		.notNull()
 		.defaultNow(),
@@ -126,9 +123,6 @@ export const habit = pgTable("habit", {
 		.notNull()
 		.defaultNow(),
 });
-
-// ステータス用の ENUM 定義
-export const recordStatusEnum = pgEnum("record_status", ["done", "missed"]);
 
 export const dailyRecord = pgTable(
 	"daily_record",
@@ -138,8 +132,10 @@ export const dailyRecord = pgTable(
 			.notNull()
 			.references(() => habit.id, { onDelete: "cascade" }),
 		date: date("date", { mode: "string" }).notNull(), // 'YYYY-MM-DD' として扱う
-		status: recordStatusEnum("status").notNull(),
-		completedAt: timestamp("completedAt", { mode: "date", withTimezone: true }),
+		completedAt: timestamp("completedAt", {
+			mode: "date",
+			withTimezone: true,
+		}).notNull(),
 	},
 	// 同一日に同じ習慣の記録が重複しないよう、複合ユニーク制約を設定
 	(table) => [unique("habit_date_unique").on(table.habitId, table.date)],

--- a/web-app/drizzle/0001_regular_inhumans.sql
+++ b/web-app/drizzle/0001_regular_inhumans.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "habit" ALTER COLUMN "emoji" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "habit" ADD COLUMN "archivedAt" timestamp with time zone;--> statement-breakpoint
+UPDATE "habit" SET "archivedAt" = "updatedAt" WHERE "isArchived" = true;--> statement-breakpoint
+DELETE FROM "daily_record" WHERE "status" <> 'done' OR "completedAt" IS NULL;--> statement-breakpoint
+ALTER TABLE "daily_record" ALTER COLUMN "completedAt" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "daily_record" DROP COLUMN "status";--> statement-breakpoint
+ALTER TABLE "habit" DROP COLUMN "deadTime";--> statement-breakpoint
+ALTER TABLE "habit" DROP COLUMN "isArchived";--> statement-breakpoint
+DROP TYPE "public"."record_status";

--- a/web-app/drizzle/meta/0001_snapshot.json
+++ b/web-app/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,555 @@
+{
+	"id": "49cc405c-e778-496f-9200-97a8cd4e3c8c",
+	"prevId": "6ee89e93-52ce-4aed-97e2-eb0a550ad6ec",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"providerId": {
+					"name": "providerId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"accessToken": {
+					"name": "accessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refreshToken": {
+					"name": "refreshToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"idToken": {
+					"name": "idToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accessTokenExpiresAt": {
+					"name": "accessTokenExpiresAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refreshTokenExpiresAt": {
+					"name": "refreshTokenExpiresAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_userId_user_id_fk": {
+					"name": "account_userId_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.daily_record": {
+			"name": "daily_record",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"habitId": {
+					"name": "habitId",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completedAt": {
+					"name": "completedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"daily_record_habitId_habit_id_fk": {
+					"name": "daily_record_habitId_habit_id_fk",
+					"tableFrom": "daily_record",
+					"tableTo": "habit",
+					"columnsFrom": ["habitId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"habit_date_unique": {
+					"name": "habit_date_unique",
+					"nullsNotDistinct": false,
+					"columns": ["habitId", "date"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.habit": {
+			"name": "habit",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"emoji": {
+					"name": "emoji",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"currentStreak": {
+					"name": "currentStreak",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"maxStreak": {
+					"name": "maxStreak",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"archivedAt": {
+					"name": "archivedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"habit_userId_user_id_fk": {
+					"name": "habit_userId_user_id_fk",
+					"tableFrom": "habit",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.push_subscription": {
+			"name": "push_subscription",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"push_subscription_userId_user_id_fk": {
+					"name": "push_subscription_userId_user_id_fk",
+					"tableFrom": "push_subscription",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"push_subscription_token_unique": {
+					"name": "push_subscription_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ipAddress": {
+					"name": "ipAddress",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"userAgent": {
+					"name": "userAgent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"session_userId_user_id_fk": {
+					"name": "session_userId_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.share_link": {
+			"name": "share_link",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"isActive": {
+					"name": "isActive",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"share_link_userId_user_id_fk": {
+					"name": "share_link_userId_user_id_fk",
+					"tableFrom": "share_link",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timezone": {
+					"name": "timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'Asia/Tokyo'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
 			"when": 1772269933443,
 			"tag": "0000_regular_deathstrike",
 			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1780735283984,
+			"tag": "0001_regular_inhumans",
+			"breakpoints": true
 		}
 	]
 }


### PR DESCRIPTION
## 概要

- Drizzle スキーマを、MVP の DB 設計書に合わせました。
- 旧設計の `daily_record.status` / `record_status` と、`habit.deadTime` / `habit.isArchived` を廃止しました。
- `habit.archivedAt` を追加し、`daily_record.completedAt` を必須化して、「達成時だけ記録を作る」設計を DB 上でも表現できるようにしました。
- スキーマ変更に対応する Drizzle マイグレーションと snapshot を追加しました。

## マイグレーション内容

- `isArchived = true` の既存データは、`archivedAt = updatedAt` として引き継ぎます。
- 旧設計の `missed` レコード、または `completedAt IS NULL` の `daily_record` は、達成記録ではないため削除します。
- その後 `daily_record.completedAt` を `NOT NULL` に変更します。

## 確認したこと

- `pnpm run typecheck`
- `pnpm exec biome check app/db/schema.ts drizzle/meta/_journal.json drizzle/meta/0001_snapshot.json`
- `pnpm run db:generate` で追加の schema 差分がないことを確認