### PR TITLE
POST /api/habits/:id/complete を実装

### DIFF
--- a/web-app/biome.json
+++ b/web-app/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
 	"files": {
 		"ignoreUnknown": true,

--- a/web-app/src/features/habits/complete-habit.integration.test.ts
+++ b/web-app/src/features/habits/complete-habit.integration.test.ts
@@ -1,0 +1,238 @@
+import { and, count, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { db } from "~/db/index.server";
+import { dailyRecord, habit, user } from "~/db/schema";
+import type { AuthenticatedUser } from "~/lib/api/auth.server";
+import { ApiError } from "~/lib/api/errors";
+import { completeHabit } from "./habits.service.server";
+
+const baseNow = new Date("2026-07-12T03:00:00.000Z");
+let owner: AuthenticatedUser;
+
+async function insertHabit(
+	values: Partial<typeof habit.$inferInsert> = {},
+): Promise<typeof habit.$inferSelect> {
+	const [created] = await db
+		.insert(habit)
+		.values({
+			userId: owner.id,
+			name: "読書",
+			emoji: "📚",
+			createdAt: baseNow,
+			updatedAt: baseNow,
+			...values,
+		})
+		.returning();
+
+	if (!created) {
+		throw new Error("テスト用habitを作成できませんでした。");
+	}
+	return created;
+}
+
+describe("completeHabit PostgreSQL integration", () => {
+	beforeEach(async (context) => {
+		owner = {
+			id: `complete-habit-${context.task.id}-${crypto.randomUUID()}`,
+		} as AuthenticatedUser;
+		await db.insert(user).values({
+			id: owner.id,
+			name: owner.id,
+			email: `${owner.id}@example.test`,
+			emailVerified: true,
+			createdAt: baseNow,
+			updatedAt: baseNow,
+		});
+	});
+
+	afterEach(async () => {
+		await db.delete(habit).where(eq(habit.userId, owner.id));
+		await db.delete(user).where(eq(user.id, owner.id));
+	});
+
+	it("当日のdaily_recordを作成し、streakとhabit summaryを更新する", async () => {
+		const target = await insertHabit();
+
+		const result = await completeHabit({
+			user: owner,
+			habitId: target.id,
+			now: baseNow,
+		});
+
+		expect(result).toEqual({
+			dailyRecord: {
+				id: expect.any(String),
+				habitId: target.id,
+				date: "2026-07-12",
+				completedAt: "2026-07-12T12:00:00+09:00",
+			},
+			habit: {
+				id: target.id,
+				name: "読書",
+				emoji: "📚",
+				currentStreak: 1,
+				maxStreak: 1,
+				isCompletedToday: true,
+			},
+		});
+
+		const [recordCount] = await db
+			.select({ value: count() })
+			.from(dailyRecord)
+			.where(eq(dailyRecord.habitId, target.id));
+		expect(recordCount.value).toBe(1);
+	});
+
+	it("昨日の達成からcurrentStreakを継続し、maxStreakを維持する", async () => {
+		const target = await insertHabit({ currentStreak: 4, maxStreak: 7 });
+		await db.insert(dailyRecord).values({
+			habitId: target.id,
+			date: "2026-07-11",
+			completedAt: new Date("2026-07-11T03:00:00.000Z"),
+		});
+
+		const result = await completeHabit({
+			user: owner,
+			habitId: target.id,
+			now: baseNow,
+		});
+
+		expect(result.habit.currentStreak).toBe(5);
+		expect(result.habit.maxStreak).toBe(7);
+	});
+
+	it("昨日より前の達成からstreakを1で再開し、maxStreakを更新する", async () => {
+		const target = await insertHabit({ currentStreak: 8, maxStreak: 8 });
+		await db.insert(dailyRecord).values({
+			habitId: target.id,
+			date: "2026-07-10",
+			completedAt: new Date("2026-07-10T03:00:00.000Z"),
+		});
+
+		const result = await completeHabit({
+			user: owner,
+			habitId: target.id,
+			now: baseNow,
+		});
+
+		expect(result.habit.currentStreak).toBe(1);
+		expect(result.habit.maxStreak).toBe(8);
+	});
+
+	it("23:59:59 JSTと00:00 JSTを別の日付として記録する", async () => {
+		const target = await insertHabit();
+		const justBeforeMidnight = new Date("2026-07-11T14:59:59.999Z");
+		const midnight = new Date("2026-07-11T15:00:00.000Z");
+
+		const first = await completeHabit({
+			user: owner,
+			habitId: target.id,
+			now: justBeforeMidnight,
+		});
+		const second = await completeHabit({
+			user: owner,
+			habitId: target.id,
+			now: midnight,
+		});
+
+		expect(first.dailyRecord.date).toBe("2026-07-11");
+		expect(second.dailyRecord.date).toBe("2026-07-12");
+		expect(second.habit.currentStreak).toBe(2);
+	});
+
+	it("同日の二重達成を拒否する", async () => {
+		const target = await insertHabit();
+		await completeHabit({ user: owner, habitId: target.id, now: baseNow });
+
+		await expect(
+			completeHabit({ user: owner, habitId: target.id, now: baseNow }),
+		).rejects.toMatchObject({
+			code: "HABIT_ALREADY_COMPLETED_TODAY",
+			status: 409,
+		});
+	});
+
+	it("アーカイブ済みhabitを拒否する", async () => {
+		const target = await insertHabit({ archivedAt: baseNow });
+
+		await expect(
+			completeHabit({ user: owner, habitId: target.id, now: baseNow }),
+		).rejects.toMatchObject({ code: "HABIT_ARCHIVED", status: 409 });
+
+		const [recordCount] = await db
+			.select({ value: count() })
+			.from(dailyRecord)
+			.where(eq(dailyRecord.habitId, target.id));
+		expect(recordCount.value).toBe(0);
+	});
+
+	it("存在しないhabitと他ユーザーのhabitをHABIT_NOT_FOUNDとして扱う", async () => {
+		const otherUser = {
+			id: `other-complete-habit-${crypto.randomUUID()}`,
+		} as AuthenticatedUser;
+		await db.insert(user).values({
+			id: otherUser.id,
+			name: otherUser.id,
+			email: `${otherUser.id}@example.test`,
+			emailVerified: true,
+			createdAt: baseNow,
+			updatedAt: baseNow,
+		});
+		const otherHabit = await db
+			.insert(habit)
+			.values({
+				userId: otherUser.id,
+				name: "他ユーザーの習慣",
+				emoji: "",
+				createdAt: baseNow,
+				updatedAt: baseNow,
+			})
+			.returning({ id: habit.id });
+
+		await expect(
+			completeHabit({
+				user: owner,
+				habitId: otherHabit[0].id,
+				now: baseNow,
+			}),
+		).rejects.toMatchObject({ code: "HABIT_NOT_FOUND", status: 404 });
+		await expect(
+			completeHabit({
+				user: owner,
+				habitId: "not-a-uuid",
+				now: baseNow,
+			}),
+		).rejects.toBeInstanceOf(ApiError);
+
+		await db.delete(habit).where(eq(habit.userId, otherUser.id));
+		await db.delete(user).where(eq(user.id, otherUser.id));
+	});
+
+	it("同じhabitへの並行completeをhabit行ロックで直列化する", async () => {
+		const target = await insertHabit();
+		const results = await Promise.allSettled([
+			completeHabit({ user: owner, habitId: target.id, now: baseNow }),
+			completeHabit({ user: owner, habitId: target.id, now: baseNow }),
+		]);
+
+		expect(
+			results.filter((result) => result.status === "fulfilled"),
+		).toHaveLength(1);
+		const rejected = results.find((result) => result.status === "rejected");
+		expect((rejected as PromiseRejectedResult).reason).toMatchObject({
+			code: "HABIT_ALREADY_COMPLETED_TODAY",
+			status: 409,
+		});
+
+		const [recordCount] = await db
+			.select({ value: count() })
+			.from(dailyRecord)
+			.where(
+				and(
+					eq(dailyRecord.habitId, target.id),
+					eq(dailyRecord.date, "2026-07-12"),
+				),
+			);
+		expect(recordCount.value).toBe(1);
+	});
+});

--- a/web-app/src/features/habits/complete-habit.test.ts
+++ b/web-app/src/features/habits/complete-habit.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "~/db/index.server";
+import type { AuthenticatedUser } from "~/lib/api/auth.server";
+import { completeHabit } from "./habits.service.server";
+
+vi.mock("~/db/index.server", () => ({
+	db: { transaction: vi.fn() },
+}));
+
+const transactionMock = vi.mocked(db.transaction);
+const user = { id: "test-user" } as AuthenticatedUser;
+const habitId = "00000000-0000-4000-8000-000000000000";
+
+describe("completeHabitのDBエラー正規化", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it("DrizzleQueryErrorのcauseにあるhabit_date_unique違反を409へ変換する", async () => {
+		const postgresError = Object.assign(new Error("duplicate key"), {
+			code: "23505",
+			constraint_name: "habit_date_unique",
+		});
+		const drizzleError = Object.assign(new Error("Failed query"), {
+			cause: postgresError,
+		});
+		transactionMock.mockRejectedValueOnce(drizzleError);
+
+		await expect(
+			completeHabit({
+				user,
+				habitId,
+				now: new Date("2026-07-12T03:00:00.000Z"),
+			}),
+		).rejects.toMatchObject({
+			code: "HABIT_ALREADY_COMPLETED_TODAY",
+			status: 409,
+		});
+	});
+});

--- a/web-app/src/features/habits/habits.service.server.ts
+++ b/web-app/src/features/habits/habits.service.server.ts
@@ -100,19 +100,30 @@ async function lockHabit(
 }
 
 function isDailyRecordUniqueViolation(error: unknown): boolean {
-	if (typeof error !== "object" || error === null) {
-		return false;
+	const visited = new Set<object>();
+	let current: unknown = error;
+
+	while (typeof current === "object" && current !== null) {
+		if (visited.has(current)) {
+			return false;
+		}
+		visited.add(current);
+
+		const databaseError = current as {
+			code?: unknown;
+			constraint_name?: unknown;
+			cause?: unknown;
+		};
+		if (
+			databaseError.code === "23505" &&
+			databaseError.constraint_name === "habit_date_unique"
+		) {
+			return true;
+		}
+		current = databaseError.cause;
 	}
 
-	const databaseError = error as {
-		code?: unknown;
-		constraint_name?: unknown;
-	};
-	return (
-		databaseError.code === "23505" &&
-		(databaseError.constraint_name === undefined ||
-			databaseError.constraint_name === "habit_date_unique")
-	);
+	return false;
 }
 
 export async function createHabit(

--- a/web-app/src/features/habits/habits.service.server.ts
+++ b/web-app/src/features/habits/habits.service.server.ts
@@ -1,8 +1,8 @@
-import { eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { db } from "~/db/index.server";
-import { habit, user as userTable } from "~/db/schema";
+import { dailyRecord, habit, user as userTable } from "~/db/schema";
 import type { AuthenticatedUser } from "~/lib/api/auth.server";
-import { toJstDateTimeString } from "~/lib/api/date";
+import { getJstDateContext, toJstDateTimeString } from "~/lib/api/date";
 import { ApiError, notImplementedApiError } from "~/lib/api/errors";
 import { parseCreateHabitRequest } from "./habits.contract";
 
@@ -32,6 +32,27 @@ export type HabitMutationInput = {
 };
 
 type HabitRow = typeof habit.$inferSelect;
+type HabitTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+type HabitSummary = Pick<
+	HabitRow,
+	"id" | "name" | "emoji" | "currentStreak" | "maxStreak"
+> & {
+	isCompletedToday: boolean;
+};
+
+export type CompleteHabitResponse = {
+	dailyRecord: {
+		id: string;
+		habitId: string;
+		date: string;
+		completedAt: string;
+	};
+	habit: HabitSummary;
+};
+
+const uuidPattern =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function toHabitResponse(row: HabitRow): HabitResponse {
 	return {
@@ -43,6 +64,55 @@ function toHabitResponse(row: HabitRow): HabitResponse {
 		createdAt: toJstDateTimeString(row.createdAt),
 		archivedAt: row.archivedAt ? toJstDateTimeString(row.archivedAt) : null,
 	};
+}
+
+function toHabitSummary(row: HabitRow): HabitSummary {
+	return {
+		id: row.id,
+		name: row.name,
+		emoji: row.emoji,
+		currentStreak: row.currentStreak,
+		maxStreak: row.maxStreak,
+		isCompletedToday: true,
+	};
+}
+
+async function lockHabit(
+	tx: HabitTransaction,
+	userId: string,
+	habitId: string,
+): Promise<HabitRow> {
+	if (!uuidPattern.test(habitId)) {
+		throw new ApiError("HABIT_NOT_FOUND");
+	}
+
+	const [lockedHabit] = await tx
+		.select()
+		.from(habit)
+		.where(and(eq(habit.id, habitId), eq(habit.userId, userId)))
+		.for("update");
+
+	if (!lockedHabit) {
+		throw new ApiError("HABIT_NOT_FOUND");
+	}
+
+	return lockedHabit;
+}
+
+function isDailyRecordUniqueViolation(error: unknown): boolean {
+	if (typeof error !== "object" || error === null) {
+		return false;
+	}
+
+	const databaseError = error as {
+		code?: unknown;
+		constraint_name?: unknown;
+	};
+	return (
+		databaseError.code === "23505" &&
+		(databaseError.constraint_name === undefined ||
+			databaseError.constraint_name === "habit_date_unique")
+	);
 }
 
 export async function createHabit(
@@ -100,7 +170,77 @@ export async function archiveHabit(_input: HabitMutationInput): Promise<never> {
 }
 
 export async function completeHabit(
-	_input: HabitMutationInput,
-): Promise<never> {
-	throw notImplementedApiError("POST /api/habits/:id/complete");
+	input: HabitMutationInput,
+): Promise<CompleteHabitResponse> {
+	const now = input.now ?? new Date();
+	const { today, yesterday } = getJstDateContext(now);
+
+	try {
+		return await db.transaction(async (tx) => {
+			// update / archive と同じ habit 行ロックを使い、操作の成立順を直列化する。
+			const lockedHabit = await lockHabit(tx, input.user.id, input.habitId);
+			if (lockedHabit.archivedAt !== null) {
+				throw new ApiError("HABIT_ARCHIVED");
+			}
+
+			const [latestRecord] = await tx
+				.select({ date: dailyRecord.date })
+				.from(dailyRecord)
+				.where(eq(dailyRecord.habitId, lockedHabit.id))
+				.orderBy(desc(dailyRecord.date))
+				.limit(1);
+
+			if (latestRecord?.date === today) {
+				throw new ApiError("HABIT_ALREADY_COMPLETED_TODAY");
+			}
+
+			const currentStreak =
+				latestRecord?.date === yesterday ? lockedHabit.currentStreak + 1 : 1;
+			const maxStreak = Math.max(lockedHabit.maxStreak, currentStreak);
+
+			const [createdRecord] = await tx
+				.insert(dailyRecord)
+				.values({
+					habitId: lockedHabit.id,
+					date: today,
+					completedAt: now,
+				})
+				.returning();
+
+			if (!createdRecord) {
+				throw new Error("達成記録の作成結果を取得できませんでした。");
+			}
+
+			const [updatedHabit] = await tx
+				.update(habit)
+				.set({
+					currentStreak,
+					maxStreak,
+					updatedAt: now,
+				})
+				.where(eq(habit.id, lockedHabit.id))
+				.returning();
+
+			if (!updatedHabit) {
+				throw new Error("習慣の更新結果を取得できませんでした。");
+			}
+
+			return {
+				dailyRecord: {
+					id: createdRecord.id,
+					habitId: createdRecord.habitId,
+					date: createdRecord.date,
+					completedAt: toJstDateTimeString(createdRecord.completedAt),
+				},
+				habit: toHabitSummary(updatedHabit),
+			};
+		});
+	} catch (error) {
+		if (isDailyRecordUniqueViolation(error)) {
+			throw new ApiError("HABIT_ALREADY_COMPLETED_TODAY", undefined, {
+				cause: error,
+			});
+		}
+		throw error;
+	}
 }


### PR DESCRIPTION
## 概要

Issue #34の `POST /api/habits/:id/complete` を実装しました。

## 変更内容

- JST基準の当日 `daily_record` 作成
- 昨日からの継続・途切れたstreakの再開、および`maxStreak`更新
- habit行の`FOR UPDATE`ロックによるupdate / archive / completeの直列化基盤
- アーカイブ済み、存在しない・他ユーザー所有、当日二重達成のエラー処理
- `UNIQUE(habitId, date)`違反の`HABIT_ALREADY_COMPLETED_TODAY`への正規化
- 作成した`dailyRecord`と更新後のhabit summaryを`201 Created`で返却
- JSTの日付境界、streak、競合を確認するPostgreSQL統合テストを追加

## 確認

- `tsc --pretty false`
- `biome check .`
- `vitest run`（48 tests passed）
- `vite build`
- PostgreSQL統合テストは、実行環境に`DATABASE_URL`が未設定のため未実行

Closes #34
