### PR TITLE
PATCH /api/habits/:id を実装

### DIFF
--- a/web-app/src/features/habits/habits.contract.test.ts
+++ b/web-app/src/features/habits/habits.contract.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { ApiError } from "~/lib/api/errors";
-import { parseCreateHabitRequest } from "./habits.contract";
+import {
+	parseCreateHabitRequest,
+	parseUpdateHabitRequest,
+} from "./habits.contract";
 
 describe("parseCreateHabitRequest", () => {
 	it("習慣名をtrimし、絵文字の未指定を空文字へ正規化する", () => {
@@ -61,5 +64,74 @@ describe("parseCreateHabitRequest", () => {
 	it("50グラフェムの習慣名を受け付ける", () => {
 		const name = "🌱".repeat(50);
 		expect(parseCreateHabitRequest({ name })).toEqual({ name, emoji: "" });
+	});
+});
+
+describe("parseUpdateHabitRequest", () => {
+	it("nameだけをtrimして受け付ける", () => {
+		expect(parseUpdateHabitRequest({ name: "  毎日読書する  " })).toEqual({
+			name: "毎日読書する",
+		});
+	});
+
+	it("emojiだけ、またはnameとemojiの両方を受け付ける", () => {
+		expect(parseUpdateHabitRequest({ emoji: "📖" })).toEqual({
+			emoji: "📖",
+		});
+		expect(parseUpdateHabitRequest({ name: "運動", emoji: "🏃🏻‍♀️" })).toEqual({
+			name: "運動",
+			emoji: "🏃🏻‍♀️",
+		});
+	});
+
+	it("空文字のemojiを受け付ける", () => {
+		expect(parseUpdateHabitRequest({ emoji: "" })).toEqual({ emoji: "" });
+	});
+
+	it.each(["📚", "👨‍👩‍👧‍👦", "👍🏽", "🇯🇵", "1️⃣", "❤️"])(
+		"単一の絵文字グラフェムクラスタ %s を受け付ける",
+		(emoji) => {
+			expect(parseUpdateHabitRequest({ emoji })).toEqual({ emoji });
+		},
+	);
+
+	it.each([
+		undefined,
+		null,
+		[],
+		"name",
+		{},
+		{ unknown: true },
+		{ name: "習慣", currentStreak: 10 },
+		{ name: "" },
+		{ name: "   " },
+		{ name: "あ".repeat(51) },
+		{ name: null },
+		{ name: 123 },
+	])("不正なリクエスト %j を拒否する", (body) => {
+		expect(() => parseUpdateHabitRequest(body)).toThrowError(
+			expect.objectContaining({ code: "INVALID_REQUEST", status: 400 }),
+		);
+	});
+
+	it.each([
+		null,
+		"emoji",
+		"📚📖",
+		" ",
+		"❤",
+		"\u20E3",
+		"📚\uFE0E",
+		"📚\u200D",
+		1,
+	])("不正なemoji %j を拒否する", (emoji) => {
+		expect(() => parseUpdateHabitRequest({ emoji })).toThrowError(
+			expect.objectContaining({ code: "INVALID_REQUEST", status: 400 }),
+		);
+	});
+
+	it("50グラフェムの習慣名を受け付ける", () => {
+		const name = "🌱".repeat(50);
+		expect(parseUpdateHabitRequest({ name })).toEqual({ name });
 	});
 });

--- a/web-app/src/features/habits/habits.contract.ts
+++ b/web-app/src/features/habits/habits.contract.ts
@@ -6,10 +6,16 @@ const graphemeSegmenter = new Intl.Segmenter("ja", {
 // biome-ignore lint/complexity/useRegexLiterals: ES2022 targetでvフラグを使用するためコンストラクタ形式にする。
 const emojiPattern = new RegExp("^\\p{RGI_Emoji}$", "v");
 const createHabitFields = new Set(["name", "emoji"]);
+const updateHabitFields = new Set(["name", "emoji"]);
 
 export type CreateHabitRequest = {
 	name: string;
 	emoji: string;
+};
+
+export type UpdateHabitRequest = {
+	name?: string;
+	emoji?: string;
 };
 
 function invalidRequest(cause?: unknown): never {
@@ -53,4 +59,42 @@ export function parseCreateHabitRequest(body: unknown): CreateHabitRequest {
 	}
 
 	return { name, emoji };
+}
+
+export function parseUpdateHabitRequest(body: unknown): UpdateHabitRequest {
+	if (!isJsonObject(body)) {
+		return invalidRequest();
+	}
+
+	const fields = Object.keys(body);
+	if (
+		fields.length === 0 ||
+		fields.some((field) => !updateHabitFields.has(field))
+	) {
+		return invalidRequest();
+	}
+
+	const request: UpdateHabitRequest = {};
+	if ("name" in body) {
+		if (typeof body.name !== "string") {
+			return invalidRequest();
+		}
+		const name = body.name.trim();
+		if (name === "" || countGraphemes(name) > 50) {
+			return invalidRequest();
+		}
+		request.name = name;
+	}
+
+	if ("emoji" in body) {
+		if (
+			typeof body.emoji !== "string" ||
+			(body.emoji !== "" && !isSingleEmojiGrapheme(body.emoji))
+		) {
+			return invalidRequest();
+		}
+		request.emoji = body.emoji;
+	}
+
+	return request;
 }

--- a/web-app/src/features/habits/habits.service.server.ts
+++ b/web-app/src/features/habits/habits.service.server.ts
@@ -4,7 +4,10 @@ import { dailyRecord, habit, user as userTable } from "~/db/schema";
 import type { AuthenticatedUser } from "~/lib/api/auth.server";
 import { getJstDateContext, toJstDateTimeString } from "~/lib/api/date";
 import { ApiError, notImplementedApiError } from "~/lib/api/errors";
-import { parseCreateHabitRequest } from "./habits.contract";
+import {
+	parseCreateHabitRequest,
+	parseUpdateHabitRequest,
+} from "./habits.contract";
 
 const ACTIVE_HABIT_LIMIT = 10;
 const TOTAL_HABIT_LIMIT = 1000;
@@ -29,6 +32,10 @@ export type HabitMutationInput = {
 	user: AuthenticatedUser;
 	habitId: string;
 	now?: Date;
+};
+
+export type UpdateHabitInput = HabitMutationInput & {
+	body: unknown;
 };
 
 type HabitRow = typeof habit.$inferSelect;
@@ -178,6 +185,32 @@ export async function createHabit(
 
 export async function archiveHabit(_input: HabitMutationInput): Promise<never> {
 	throw notImplementedApiError("PATCH /api/habits/:id/archive");
+}
+
+export async function updateHabit(
+	input: UpdateHabitInput,
+): Promise<HabitResponse> {
+	const request = parseUpdateHabitRequest(input.body);
+	const now = input.now ?? new Date();
+
+	return db.transaction(async (tx) => {
+		const lockedHabit = await lockHabit(tx, input.user.id, input.habitId);
+		if (lockedHabit.archivedAt !== null) {
+			throw new ApiError("HABIT_ARCHIVED");
+		}
+
+		const [updatedHabit] = await tx
+			.update(habit)
+			.set({ ...request, updatedAt: now })
+			.where(eq(habit.id, lockedHabit.id))
+			.returning();
+
+		if (!updatedHabit) {
+			throw new Error("習慣の更新結果を取得できませんでした。");
+		}
+
+		return toHabitResponse(updatedHabit);
+	});
 }
 
 export async function completeHabit(

--- a/web-app/src/features/habits/update-habit.integration.test.ts
+++ b/web-app/src/features/habits/update-habit.integration.test.ts
@@ -1,0 +1,259 @@
+import { count, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { db } from "~/db/index.server";
+import { dailyRecord, habit, user } from "~/db/schema";
+import type { AuthenticatedUser } from "~/lib/api/auth.server";
+import { completeHabit, updateHabit } from "./habits.service.server";
+
+const createdAt = new Date("2026-07-10T03:00:00.000Z");
+const initialUpdatedAt = new Date("2026-07-11T03:00:00.000Z");
+const updateNow = new Date("2026-07-12T03:00:00.000Z");
+let owner: AuthenticatedUser;
+
+async function insertHabit(
+	values: Partial<typeof habit.$inferInsert> = {},
+): Promise<typeof habit.$inferSelect> {
+	const [created] = await db
+		.insert(habit)
+		.values({
+			userId: owner.id,
+			name: "読書",
+			emoji: "📚",
+			currentStreak: 4,
+			maxStreak: 8,
+			createdAt,
+			updatedAt: initialUpdatedAt,
+			...values,
+		})
+		.returning();
+
+	if (!created) {
+		throw new Error("テスト用habitを作成できませんでした。");
+	}
+	return created;
+}
+
+describe("updateHabit PostgreSQL integration", () => {
+	beforeEach(async (context) => {
+		owner = {
+			id: `update-habit-${context.task.id}-${crypto.randomUUID()}`,
+		} as AuthenticatedUser;
+		await db.insert(user).values({
+			id: owner.id,
+			name: owner.id,
+			email: `${owner.id}@example.test`,
+			emailVerified: true,
+			createdAt,
+			updatedAt: createdAt,
+		});
+	});
+
+	afterEach(async () => {
+		await db.delete(habit).where(eq(habit.userId, owner.id));
+		await db.delete(user).where(eq(user.id, owner.id));
+	});
+
+	it("nameだけを更新し、streak・作成日時・過去の達成記録を変更しない", async () => {
+		const target = await insertHabit();
+		const [record] = await db
+			.insert(dailyRecord)
+			.values({
+				habitId: target.id,
+				date: "2026-07-11",
+				completedAt: initialUpdatedAt,
+			})
+			.returning();
+
+		const result = await updateHabit({
+			user: owner,
+			habitId: target.id,
+			body: { name: "  毎日読書する  " },
+			now: updateNow,
+		});
+
+		expect(result).toEqual({
+			id: target.id,
+			name: "毎日読書する",
+			emoji: "📚",
+			currentStreak: 4,
+			maxStreak: 8,
+			createdAt: "2026-07-10T12:00:00+09:00",
+			archivedAt: null,
+		});
+
+		const [stored] = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.id, target.id));
+		expect(stored).toMatchObject({
+			name: "毎日読書する",
+			emoji: "📚",
+			currentStreak: 4,
+			maxStreak: 8,
+			createdAt,
+			archivedAt: null,
+			updatedAt: updateNow,
+		});
+		expect(
+			await db
+				.select()
+				.from(dailyRecord)
+				.where(eq(dailyRecord.habitId, target.id)),
+		).toEqual([record]);
+	});
+
+	it("emojiだけを更新し、空文字で未設定へ戻せる", async () => {
+		const target = await insertHabit();
+
+		const changed = await updateHabit({
+			user: owner,
+			habitId: target.id,
+			body: { emoji: "📖" },
+			now: updateNow,
+		});
+		expect(changed).toMatchObject({ name: "読書", emoji: "📖" });
+
+		const cleared = await updateHabit({
+			user: owner,
+			habitId: target.id,
+			body: { emoji: "" },
+			now: updateNow,
+		});
+		expect(cleared).toMatchObject({ name: "読書", emoji: "" });
+	});
+
+	it("nameとemojiを同時に更新する", async () => {
+		const target = await insertHabit();
+
+		const result = await updateHabit({
+			user: owner,
+			habitId: target.id,
+			body: { name: "運動", emoji: "🏃" },
+			now: updateNow,
+		});
+
+		expect(result).toMatchObject({ name: "運動", emoji: "🏃" });
+	});
+
+	it("値が変わらない更新も成功し、updatedAtだけを更新する", async () => {
+		const target = await insertHabit();
+
+		const result = await updateHabit({
+			user: owner,
+			habitId: target.id,
+			body: { name: "読書", emoji: "📚" },
+			now: updateNow,
+		});
+
+		expect(result).toMatchObject({ name: "読書", emoji: "📚" });
+		const [stored] = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.id, target.id));
+		expect(stored).toEqual({ ...target, updatedAt: updateNow });
+	});
+
+	it("アーカイブ済みhabitを拒否し、DB状態を変更しない", async () => {
+		const archivedAt = new Date("2026-07-11T12:00:00.000Z");
+		const target = await insertHabit({ archivedAt });
+
+		await expect(
+			updateHabit({
+				user: owner,
+				habitId: target.id,
+				body: { name: "変更後" },
+				now: updateNow,
+			}),
+		).rejects.toMatchObject({ code: "HABIT_ARCHIVED", status: 409 });
+
+		const [stored] = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.id, target.id));
+		expect(stored).toEqual(target);
+	});
+
+	it("存在しないhabitと他ユーザーのhabitをHABIT_NOT_FOUNDとして扱う", async () => {
+		const otherUserId = `other-update-habit-${crypto.randomUUID()}`;
+		await db.insert(user).values({
+			id: otherUserId,
+			name: otherUserId,
+			email: `${otherUserId}@example.test`,
+			emailVerified: true,
+			createdAt,
+			updatedAt: createdAt,
+		});
+		const [otherHabit] = await db
+			.insert(habit)
+			.values({
+				userId: otherUserId,
+				name: "他ユーザーの習慣",
+				emoji: "",
+				createdAt,
+				updatedAt: createdAt,
+			})
+			.returning();
+
+		await expect(
+			updateHabit({
+				user: owner,
+				habitId: otherHabit.id,
+				body: { name: "変更後" },
+				now: updateNow,
+			}),
+		).rejects.toMatchObject({ code: "HABIT_NOT_FOUND", status: 404 });
+		await expect(
+			updateHabit({
+				user: owner,
+				habitId: crypto.randomUUID(),
+				body: { name: "変更後" },
+				now: updateNow,
+			}),
+		).rejects.toMatchObject({ code: "HABIT_NOT_FOUND", status: 404 });
+		await expect(
+			updateHabit({
+				user: owner,
+				habitId: "not-a-uuid",
+				body: { name: "変更後" },
+				now: updateNow,
+			}),
+		).rejects.toMatchObject({ code: "HABIT_NOT_FOUND", status: 404 });
+
+		await db.delete(habit).where(eq(habit.userId, otherUserId));
+		await db.delete(user).where(eq(user.id, otherUserId));
+	});
+
+	it("completeとの競合をhabit行ロックで直列化し、両方の更新を保持する", async () => {
+		const target = await insertHabit({ currentStreak: 0, maxStreak: 0 });
+
+		const [updateResult, completeResult] = await Promise.all([
+			updateHabit({
+				user: owner,
+				habitId: target.id,
+				body: { name: "更新後", emoji: "🌱" },
+				now: updateNow,
+			}),
+			completeHabit({ user: owner, habitId: target.id, now: updateNow }),
+		]);
+
+		const updateSawComplete = updateResult.currentStreak === 1;
+		const completeSawUpdate = completeResult.habit.name === "更新後";
+		expect(Number(updateSawComplete) + Number(completeSawUpdate)).toBe(1);
+
+		const [stored] = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.id, target.id));
+		expect(stored).toMatchObject({
+			name: "更新後",
+			emoji: "🌱",
+			currentStreak: 1,
+			maxStreak: 1,
+		});
+		const [recordCount] = await db
+			.select({ value: count() })
+			.from(dailyRecord)
+			.where(eq(dailyRecord.habitId, target.id));
+		expect(recordCount.value).toBe(1);
+	});
+});

--- a/web-app/src/lib/api/request.test.ts
+++ b/web-app/src/lib/api/request.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { parseJsonBody } from "./request";
+
+describe("parseJsonBody", () => {
+	it("空のリクエストボディをINVALID_REQUESTとして拒否する", async () => {
+		await expect(
+			parseJsonBody(
+				new Request("http://localhost/api/habits/id", {
+					method: "PATCH",
+				}),
+			),
+		).rejects.toMatchObject({ code: "INVALID_REQUEST", status: 400 });
+	});
+
+	it("JSONとして不正なリクエストボディをINVALID_REQUESTとして拒否する", async () => {
+		await expect(
+			parseJsonBody(
+				new Request("http://localhost/api/habits/id", {
+					method: "PATCH",
+					body: "not-json",
+				}),
+			),
+		).rejects.toMatchObject({ code: "INVALID_REQUEST", status: 400 });
+	});
+});

--- a/web-app/src/lib/api/routes.test.ts
+++ b/web-app/src/lib/api/routes.test.ts
@@ -32,17 +32,24 @@ const appApiRoutes = [
 		method: "POST",
 	},
 	{
+		file: "src/routes/api/habits/$habitId.ts",
+		path: 'createFileRoute("/api/habits/$habitId")',
+		fullPath: "'/api/habits/$habitId'",
+		parentRoute: "ApiHabitsRoute",
+		method: "PATCH",
+	},
+	{
 		file: "src/routes/api/habits/$habitId/archive.ts",
 		path: 'createFileRoute("/api/habits/$habitId/archive")',
 		fullPath: "'/api/habits/$habitId/archive'",
-		parentRoute: "ApiHabitsRoute",
+		parentRoute: "ApiHabitsHabitIdRoute",
 		method: "PATCH",
 	},
 	{
 		file: "src/routes/api/habits/$habitId/complete.ts",
 		path: 'createFileRoute("/api/habits/$habitId/complete")',
 		fullPath: "'/api/habits/$habitId/complete'",
-		parentRoute: "ApiHabitsRoute",
+		parentRoute: "ApiHabitsHabitIdRoute",
 		method: "POST",
 	},
 ];

--- a/web-app/src/routeTree.gen.ts
+++ b/web-app/src/routeTree.gen.ts
@@ -10,32 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as HealthReadyRouteImport } from './routes/health/ready'
-import { Route as HealthLiveRouteImport } from './routes/health/live'
-import { Route as ApiHomeRouteImport } from './routes/api/home'
 import { Route as ApiHabitsRouteImport } from './routes/api/habits'
+import { Route as ApiHomeRouteImport } from './routes/api/home'
+import { Route as HealthLiveRouteImport } from './routes/health/live'
+import { Route as HealthReadyRouteImport } from './routes/health/ready'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
-import { Route as ApiHabitsHabitIdCompleteRouteImport } from './routes/api/habits/$habitId/complete'
+import { Route as ApiHabitsHabitIdRouteImport } from './routes/api/habits/$habitId'
 import { Route as ApiHabitsHabitIdArchiveRouteImport } from './routes/api/habits/$habitId/archive'
+import { Route as ApiHabitsHabitIdCompleteRouteImport } from './routes/api/habits/$habitId/complete'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const HealthReadyRoute = HealthReadyRouteImport.update({
-  id: '/health/ready',
-  path: '/health/ready',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const HealthLiveRoute = HealthLiveRouteImport.update({
-  id: '/health/live',
-  path: '/health/live',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiHomeRoute = ApiHomeRouteImport.update({
-  id: '/api/home',
-  path: '/api/home',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiHabitsRoute = ApiHabitsRouteImport.update({
@@ -43,22 +29,42 @@ const ApiHabitsRoute = ApiHabitsRouteImport.update({
   path: '/api/habits',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHomeRoute = ApiHomeRouteImport.update({
+  id: '/api/home',
+  path: '/api/home',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HealthLiveRoute = HealthLiveRouteImport.update({
+  id: '/health/live',
+  path: '/health/live',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HealthReadyRoute = HealthReadyRouteImport.update({
+  id: '/health/ready',
+  path: '/health/ready',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   id: '/api/auth/$',
   path: '/api/auth/$',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiHabitsHabitIdCompleteRoute =
-  ApiHabitsHabitIdCompleteRouteImport.update({
-    id: '/$habitId/complete',
-    path: '/$habitId/complete',
-    getParentRoute: () => ApiHabitsRoute,
-  } as any)
-const ApiHabitsHabitIdArchiveRoute = ApiHabitsHabitIdArchiveRouteImport.update({
-  id: '/$habitId/archive',
-  path: '/$habitId/archive',
+const ApiHabitsHabitIdRoute = ApiHabitsHabitIdRouteImport.update({
+  id: '/$habitId',
+  path: '/$habitId',
   getParentRoute: () => ApiHabitsRoute,
 } as any)
+const ApiHabitsHabitIdArchiveRoute = ApiHabitsHabitIdArchiveRouteImport.update({
+  id: '/archive',
+  path: '/archive',
+  getParentRoute: () => ApiHabitsHabitIdRoute,
+} as any)
+const ApiHabitsHabitIdCompleteRoute =
+  ApiHabitsHabitIdCompleteRouteImport.update({
+    id: '/complete',
+    path: '/complete',
+    getParentRoute: () => ApiHabitsHabitIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -67,6 +73,7 @@ export interface FileRoutesByFullPath {
   '/health/live': typeof HealthLiveRoute
   '/health/ready': typeof HealthReadyRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/habits/$habitId': typeof ApiHabitsHabitIdRouteWithChildren
   '/api/habits/$habitId/archive': typeof ApiHabitsHabitIdArchiveRoute
   '/api/habits/$habitId/complete': typeof ApiHabitsHabitIdCompleteRoute
 }
@@ -77,6 +84,7 @@ export interface FileRoutesByTo {
   '/health/live': typeof HealthLiveRoute
   '/health/ready': typeof HealthReadyRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/habits/$habitId': typeof ApiHabitsHabitIdRouteWithChildren
   '/api/habits/$habitId/archive': typeof ApiHabitsHabitIdArchiveRoute
   '/api/habits/$habitId/complete': typeof ApiHabitsHabitIdCompleteRoute
 }
@@ -88,6 +96,7 @@ export interface FileRoutesById {
   '/health/live': typeof HealthLiveRoute
   '/health/ready': typeof HealthReadyRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/habits/$habitId': typeof ApiHabitsHabitIdRouteWithChildren
   '/api/habits/$habitId/archive': typeof ApiHabitsHabitIdArchiveRoute
   '/api/habits/$habitId/complete': typeof ApiHabitsHabitIdCompleteRoute
 }
@@ -100,6 +109,7 @@ export interface FileRouteTypes {
     | '/health/live'
     | '/health/ready'
     | '/api/auth/$'
+    | '/api/habits/$habitId'
     | '/api/habits/$habitId/archive'
     | '/api/habits/$habitId/complete'
   fileRoutesByTo: FileRoutesByTo
@@ -110,6 +120,7 @@ export interface FileRouteTypes {
     | '/health/live'
     | '/health/ready'
     | '/api/auth/$'
+    | '/api/habits/$habitId'
     | '/api/habits/$habitId/archive'
     | '/api/habits/$habitId/complete'
   id:
@@ -120,6 +131,7 @@ export interface FileRouteTypes {
     | '/health/live'
     | '/health/ready'
     | '/api/auth/$'
+    | '/api/habits/$habitId'
     | '/api/habits/$habitId/archive'
     | '/api/habits/$habitId/complete'
   fileRoutesById: FileRoutesById
@@ -142,18 +154,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/health/ready': {
-      id: '/health/ready'
-      path: '/health/ready'
-      fullPath: '/health/ready'
-      preLoaderRoute: typeof HealthReadyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/health/live': {
-      id: '/health/live'
-      path: '/health/live'
-      fullPath: '/health/live'
-      preLoaderRoute: typeof HealthLiveRouteImport
+    '/api/habits': {
+      id: '/api/habits'
+      path: '/api/habits'
+      fullPath: '/api/habits'
+      preLoaderRoute: typeof ApiHabitsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/home': {
@@ -163,11 +168,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiHomeRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/habits': {
-      id: '/api/habits'
-      path: '/api/habits'
-      fullPath: '/api/habits'
-      preLoaderRoute: typeof ApiHabitsRouteImport
+    '/health/live': {
+      id: '/health/live'
+      path: '/health/live'
+      fullPath: '/health/live'
+      preLoaderRoute: typeof HealthLiveRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/health/ready': {
+      id: '/health/ready'
+      path: '/health/ready'
+      fullPath: '/health/ready'
+      preLoaderRoute: typeof HealthReadyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/auth/$': {
@@ -177,31 +189,49 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAuthSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/habits/$habitId/complete': {
-      id: '/api/habits/$habitId/complete'
-      path: '/$habitId/complete'
-      fullPath: '/api/habits/$habitId/complete'
-      preLoaderRoute: typeof ApiHabitsHabitIdCompleteRouteImport
+    '/api/habits/$habitId': {
+      id: '/api/habits/$habitId'
+      path: '/$habitId'
+      fullPath: '/api/habits/$habitId'
+      preLoaderRoute: typeof ApiHabitsHabitIdRouteImport
       parentRoute: typeof ApiHabitsRoute
     }
     '/api/habits/$habitId/archive': {
       id: '/api/habits/$habitId/archive'
-      path: '/$habitId/archive'
+      path: '/archive'
       fullPath: '/api/habits/$habitId/archive'
       preLoaderRoute: typeof ApiHabitsHabitIdArchiveRouteImport
-      parentRoute: typeof ApiHabitsRoute
+      parentRoute: typeof ApiHabitsHabitIdRoute
+    }
+    '/api/habits/$habitId/complete': {
+      id: '/api/habits/$habitId/complete'
+      path: '/complete'
+      fullPath: '/api/habits/$habitId/complete'
+      preLoaderRoute: typeof ApiHabitsHabitIdCompleteRouteImport
+      parentRoute: typeof ApiHabitsHabitIdRoute
     }
   }
 }
 
-interface ApiHabitsRouteChildren {
+interface ApiHabitsHabitIdRouteChildren {
   ApiHabitsHabitIdArchiveRoute: typeof ApiHabitsHabitIdArchiveRoute
   ApiHabitsHabitIdCompleteRoute: typeof ApiHabitsHabitIdCompleteRoute
 }
 
-const ApiHabitsRouteChildren: ApiHabitsRouteChildren = {
+const ApiHabitsHabitIdRouteChildren: ApiHabitsHabitIdRouteChildren = {
   ApiHabitsHabitIdArchiveRoute: ApiHabitsHabitIdArchiveRoute,
   ApiHabitsHabitIdCompleteRoute: ApiHabitsHabitIdCompleteRoute,
+}
+
+const ApiHabitsHabitIdRouteWithChildren =
+  ApiHabitsHabitIdRoute._addFileChildren(ApiHabitsHabitIdRouteChildren)
+
+interface ApiHabitsRouteChildren {
+  ApiHabitsHabitIdRoute: typeof ApiHabitsHabitIdRouteWithChildren
+}
+
+const ApiHabitsRouteChildren: ApiHabitsRouteChildren = {
+  ApiHabitsHabitIdRoute: ApiHabitsHabitIdRouteWithChildren,
 }
 
 const ApiHabitsRouteWithChildren = ApiHabitsRoute._addFileChildren(

--- a/web-app/src/routes/api/habits/$habitId.ts
+++ b/web-app/src/routes/api/habits/$habitId.ts
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { updateHabit } from "~/features/habits/habits.service.server";
+import { parseJsonBody } from "~/lib/api/request";
+import { handleAuthenticatedApi } from "~/lib/api/route.server";
+
+export const Route = createFileRoute("/api/habits/$habitId")({
+	server: {
+		handlers: {
+			PATCH: ({ request, params }) =>
+				handleAuthenticatedApi(
+					request,
+					async ({ request: authenticatedRequest, user }) => {
+						const body = await parseJsonBody(authenticatedRequest);
+						return updateHabit({ user, habitId: params.habitId, body });
+					},
+				),
+		},
+	},
+});


### PR DESCRIPTION
## 概要

active habit の名前・絵文字を更新する `PATCH /api/habits/:id` を実装しました。

Refs #67

> [!NOTE]
> update / archive の実操作間競合は、依存する archive 実装（#35）で両方の成立順を PostgreSQL 統合テストに追加して確認します。その完了まで #67 は open のまま維持します。

## 変更内容

- `name` / `emoji` の部分更新と入力バリデーションを追加
- #34 で導入された habit 行の `FOR UPDATE` ロックを update でも再利用
- 所有者確認、アーカイブ済み判定、統一エラー形式に対応
- `name` / `emoji` / `updatedAt` 以外を変更しない更新処理を追加
- TanStack の動的 API ルートと生成 route tree を追加
- バリデーション、DB 不変条件、update / complete 競合のテストを追加

## 影響

ホーム画面などのクライアントから、active habit の表示名と絵文字だけを安全に更新できるようになります。同一 habit に対する complete と update は共通行ロックで直列化され、先に成立した処理を優先します。

## 検証

- `pnpm test`（82件成功）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run test:integration` はローカルに `DATABASE_URL` がないため未実行。GitHub Actions の PostgreSQL 統合テストで確認します。
