### PR TITLE
GET /api/home を実装

### DIFF
--- a/web-app/src/features/home/home.service.integration.test.ts
+++ b/web-app/src/features/home/home.service.integration.test.ts
@@ -1,0 +1,459 @@
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { db } from "~/db/index.server";
+import { dailyRecord, habit, user } from "~/db/schema";
+import {
+	archiveHabit,
+	completeHabit,
+	updateHabit,
+} from "~/features/habits/habits.service.server";
+import type { AuthenticatedUser } from "~/lib/api/auth.server";
+import { addDaysToJstDateString } from "~/lib/api/date";
+import { getHomeData, type HomeDataResponse } from "./home.service.server";
+
+const now = new Date("2026-07-12T03:00:00.000Z");
+const initialUpdatedAt = new Date("2026-07-01T03:00:00.000Z");
+let owner: AuthenticatedUser;
+
+async function insertHabit(
+	values: Partial<typeof habit.$inferInsert> = {},
+): Promise<typeof habit.$inferSelect> {
+	const [created] = await db
+		.insert(habit)
+		.values({
+			userId: owner.id,
+			name: "読書",
+			emoji: "📚",
+			createdAt: new Date("2026-07-01T03:00:00.000Z"),
+			updatedAt: initialUpdatedAt,
+			...values,
+		})
+		.returning();
+
+	if (!created) {
+		throw new Error("テスト用habitを作成できませんでした。");
+	}
+	return created;
+}
+
+async function insertRecord(habitId: string, date: string): Promise<void> {
+	await db.insert(dailyRecord).values({
+		habitId,
+		date,
+		completedAt: new Date(`${date}T03:00:00.000Z`),
+	});
+}
+
+function getActivity(
+	result: HomeDataResponse,
+	date: string,
+): HomeDataResponse["activityLog"][number] {
+	const entry = result.activityLog.find((item) => item.date === date);
+	if (!entry) {
+		throw new Error(`${date}のActivity Logがありません。`);
+	}
+	return entry;
+}
+
+async function waitForHabitLockWaiters(expected: number): Promise<void> {
+	for (let attempt = 0; attempt < 200; attempt += 1) {
+		const result = await db.execute(sql`
+			select count(*)::int as "waiting"
+			from pg_stat_activity
+			where datname = current_database()
+				and pid <> pg_backend_pid()
+				and wait_event_type = 'Lock'
+				and query ilike '%from "habit"%for update%'
+		`);
+		if (Number(result[0]?.waiting ?? 0) >= expected) {
+			return;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`habit行ロックの待機数が${expected}件になりませんでした。`);
+}
+
+async function runHabitOperationsInOrder<TFirst, TSecond>(
+	habitId: string,
+	first: () => Promise<TFirst>,
+	second: () => Promise<TSecond>,
+): Promise<[PromiseSettledResult<TFirst>, PromiseSettledResult<TSecond>]> {
+	let releaseBlocker: (() => void) | undefined;
+	let notifyLocked: (() => void) | undefined;
+	const blockerRelease = new Promise<void>((resolve) => {
+		releaseBlocker = resolve;
+	});
+	const blockerLocked = new Promise<void>((resolve) => {
+		notifyLocked = resolve;
+	});
+
+	const blocker = db.transaction(async (tx) => {
+		await tx
+			.select({ id: habit.id })
+			.from(habit)
+			.where(eq(habit.id, habitId))
+			.for("update");
+		notifyLocked?.();
+		await blockerRelease;
+	});
+
+	await blockerLocked;
+	let firstPromise: Promise<TFirst> | undefined;
+	let secondPromise: Promise<TSecond> | undefined;
+	try {
+		firstPromise = first();
+		await waitForHabitLockWaiters(1);
+		secondPromise = second();
+		await waitForHabitLockWaiters(2);
+		releaseBlocker?.();
+		return await Promise.allSettled([firstPromise, secondPromise]);
+	} finally {
+		releaseBlocker?.();
+		await Promise.allSettled([
+			blocker,
+			...(firstPromise ? [firstPromise] : []),
+			...(secondPromise ? [secondPromise] : []),
+		]);
+	}
+}
+
+describe("getHomeData PostgreSQL integration", () => {
+	beforeEach(async (context) => {
+		owner = {
+			id: `home-${context.task.id}-${crypto.randomUUID()}`,
+		} as AuthenticatedUser;
+		await db.insert(user).values({
+			id: owner.id,
+			name: owner.id,
+			email: `${owner.id}@example.test`,
+			emailVerified: true,
+			createdAt: initialUpdatedAt,
+			updatedAt: initialUpdatedAt,
+		});
+	});
+
+	afterEach(async () => {
+		await db.delete(habit).where(eq(habit.userId, owner.id));
+		await db.delete(user).where(eq(user.id, owner.id));
+	});
+
+	it("habitがなくても今日を含む365日をoldestから昇順で返す", async () => {
+		const result = await getHomeData({ user: owner, now });
+
+		expect(result.habits).toEqual([]);
+		expect(result.activityLog).toHaveLength(365);
+		expect(result.activityLog[0]).toEqual({
+			date: "2025-07-13",
+			completionRate: null,
+		});
+		expect(result.activityLog.at(-1)).toEqual({
+			date: "2026-07-12",
+			completionRate: null,
+		});
+		for (let index = 1; index < result.activityLog.length; index += 1) {
+			expect(result.activityLog[index].date).toBe(
+				addDaysToJstDateString(result.activityLog[index - 1].date, 1),
+			);
+		}
+	});
+
+	it("active habitだけをname、createdAt、idの順に安定ソートする", async () => {
+		const early = new Date("2026-07-01T00:00:00.000Z");
+		const late = new Date("2026-07-02T00:00:00.000Z");
+		const ids = {
+			nameFirst: "00000000-0000-4000-8000-000000000004",
+			idFirst: "00000000-0000-4000-8000-000000000001",
+			idSecond: "00000000-0000-4000-8000-000000000002",
+			createdLater: "00000000-0000-4000-8000-000000000003",
+		};
+		await insertHabit({ id: ids.createdLater, name: "b", createdAt: late });
+		await insertHabit({ id: ids.idSecond, name: "b", createdAt: early });
+		await insertHabit({ id: ids.nameFirst, name: "a", createdAt: late });
+		await insertHabit({ id: ids.idFirst, name: "b", createdAt: early });
+		await insertHabit({ name: "0", archivedAt: now });
+
+		const result = await getHomeData({ user: owner, now });
+
+		expect(result.habits.map((item) => item.id)).toEqual([
+			ids.nameFirst,
+			ids.idFirst,
+			ids.idSecond,
+			ids.createdLater,
+		]);
+	});
+
+	it("JST 23:59:59と00:00でisCompletedTodayの対象日を切り替える", async () => {
+		const target = await insertHabit();
+		await insertRecord(target.id, "2026-07-11");
+
+		const beforeMidnight = await getHomeData({
+			user: owner,
+			now: new Date("2026-07-11T14:59:59.999Z"),
+		});
+		const midnight = await getHomeData({
+			user: owner,
+			now: new Date("2026-07-11T15:00:00.000Z"),
+		});
+
+		expect(beforeMidnight.habits[0].isCompletedToday).toBe(true);
+		expect(beforeMidnight.activityLog.at(-1)?.date).toBe("2026-07-11");
+		expect(beforeMidnight.activityLog.at(-1)?.completionRate).toBeNull();
+		expect(midnight.habits[0].isCompletedToday).toBe(false);
+		expect(midnight.activityLog.at(-1)?.date).toBe("2026-07-12");
+	});
+
+	it("期限切れstreakだけを0へ補正し、昨日・今日・既存0を変更しない", async () => {
+		const noRecord = await insertHabit({ name: "no-record", currentStreak: 3 });
+		const old = await insertHabit({ name: "old", currentStreak: 4 });
+		const yesterday = await insertHabit({
+			name: "yesterday",
+			currentStreak: 5,
+		});
+		const today = await insertHabit({ name: "today", currentStreak: 6 });
+		const zero = await insertHabit({ name: "zero", currentStreak: 0 });
+		await insertRecord(old.id, "2026-07-10");
+		await insertRecord(yesterday.id, "2026-07-11");
+		await insertRecord(today.id, "2026-07-12");
+
+		const result = await getHomeData({ user: owner, now });
+		const responseById = new Map(result.habits.map((item) => [item.id, item]));
+
+		expect(responseById.get(noRecord.id)?.currentStreak).toBe(0);
+		expect(responseById.get(old.id)?.currentStreak).toBe(0);
+		expect(responseById.get(yesterday.id)?.currentStreak).toBe(5);
+		expect(responseById.get(today.id)?.currentStreak).toBe(6);
+		expect(responseById.get(zero.id)?.currentStreak).toBe(0);
+
+		const stored = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.userId, owner.id));
+		const storedById = new Map(stored.map((item) => [item.id, item]));
+		expect(storedById.get(noRecord.id)).toMatchObject({
+			currentStreak: 0,
+			updatedAt: now,
+		});
+		expect(storedById.get(old.id)).toMatchObject({
+			currentStreak: 0,
+			updatedAt: now,
+		});
+		for (const unchanged of [yesterday, today, zero]) {
+			expect(storedById.get(unchanged.id)).toMatchObject({
+				currentStreak: unchanged.currentStreak,
+				updatedAt: initialUpdatedAt,
+			});
+		}
+	});
+
+	it("createdAtの日末境界でActivity Logの分母と分子を判定する", async () => {
+		const beforeBoundary = await insertHabit({
+			name: "before",
+			createdAt: new Date("2026-07-10T14:59:59.999Z"),
+		});
+		const atBoundary = await insertHabit({
+			name: "at",
+			createdAt: new Date("2026-07-10T15:00:00.000Z"),
+		});
+		await insertHabit({
+			name: "existing",
+			createdAt: new Date("2026-07-09T03:00:00.000Z"),
+		});
+		await insertRecord(beforeBoundary.id, "2026-07-10");
+		await insertRecord(atBoundary.id, "2026-07-10");
+		await insertRecord(beforeBoundary.id, "2026-07-11");
+		await insertRecord(atBoundary.id, "2026-07-11");
+
+		const result = await getHomeData({ user: owner, now });
+
+		expect(getActivity(result, "2026-07-10").completionRate).toBe(0.5);
+		expect(getActivity(result, "2026-07-11").completionRate).toBeCloseTo(2 / 3);
+		expect(getActivity(result, "2026-07-09").completionRate).toBe(0);
+		expect(getActivity(result, "2025-07-13").completionRate).toBeNull();
+		expect(getActivity(result, "2026-07-12").completionRate).toBeNull();
+	});
+
+	it("archive後はhabitと全過去日の分子・分母から除外して再集計する", async () => {
+		const completed = await insertHabit({ name: "completed" });
+		const incomplete = await insertHabit({ name: "incomplete" });
+		await insertRecord(completed.id, "2026-07-10");
+
+		const before = await getHomeData({ user: owner, now });
+		expect(getActivity(before, "2026-07-10").completionRate).toBe(0.5);
+
+		await archiveHabit({ user: owner, habitId: completed.id, now });
+		const after = await getHomeData({ user: owner, now });
+
+		expect(after.habits.map((item) => item.id)).toEqual([incomplete.id]);
+		expect(getActivity(after, "2026-07-10").completionRate).toBe(0);
+
+		await archiveHabit({ user: owner, habitId: incomplete.id, now });
+		const afterAll = await getHomeData({ user: owner, now });
+		expect(afterAll.habits).toEqual([]);
+		expect(getActivity(afterAll, "2026-07-10").completionRate).toBeNull();
+	});
+
+	it("complete先行時は当日recordとstreakを保持してhomeの古い補正で上書きしない", async () => {
+		const target = await insertHabit({ currentStreak: 7, maxStreak: 7 });
+		const [completeResult, homeResult] = await runHabitOperationsInOrder(
+			target.id,
+			() => completeHabit({ user: owner, habitId: target.id, now }),
+			() => getHomeData({ user: owner, now }),
+		);
+
+		expect(completeResult).toMatchObject({
+			status: "fulfilled",
+			value: { habit: { currentStreak: 1 } },
+		});
+		expect(homeResult).toMatchObject({
+			status: "fulfilled",
+			value: { habits: [{ currentStreak: 1, isCompletedToday: true }] },
+		});
+		const [stored] = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.id, target.id));
+		expect(stored.currentStreak).toBe(1);
+	});
+
+	it("home先行時は期限切れ補正後にcompleteがstreakを1で開始する", async () => {
+		const target = await insertHabit({ currentStreak: 7, maxStreak: 7 });
+		const [homeResult, completeResult] = await runHabitOperationsInOrder(
+			target.id,
+			() => getHomeData({ user: owner, now }),
+			() => completeHabit({ user: owner, habitId: target.id, now }),
+		);
+
+		expect(homeResult).toMatchObject({
+			status: "fulfilled",
+			value: { habits: [{ currentStreak: 0, isCompletedToday: false }] },
+		});
+		expect(completeResult).toMatchObject({
+			status: "fulfilled",
+			value: { habit: { currentStreak: 1, maxStreak: 7 } },
+		});
+		const [stored] = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.id, target.id));
+		expect(stored.currentStreak).toBe(1);
+	});
+
+	it("archive先行時はhomeの固定active集合から除外する", async () => {
+		const target = await insertHabit();
+		await insertRecord(target.id, "2026-07-10");
+		const [archiveResult, homeResult] = await runHabitOperationsInOrder(
+			target.id,
+			() => archiveHabit({ user: owner, habitId: target.id, now }),
+			() => getHomeData({ user: owner, now }),
+		);
+
+		expect(archiveResult).toMatchObject({ status: "fulfilled" });
+		expect(homeResult).toMatchObject({
+			status: "fulfilled",
+			value: { habits: [] },
+		});
+		if (homeResult.status === "fulfilled") {
+			expect(
+				getActivity(homeResult.value, "2026-07-10").completionRate,
+			).toBeNull();
+		}
+	});
+
+	it("home先行時はactive固定集合を返した後にarchiveを成立させる", async () => {
+		const target = await insertHabit();
+		await insertRecord(target.id, "2026-07-10");
+		const [homeResult, archiveResult] = await runHabitOperationsInOrder(
+			target.id,
+			() => getHomeData({ user: owner, now }),
+			() => archiveHabit({ user: owner, habitId: target.id, now }),
+		);
+
+		expect(homeResult).toMatchObject({
+			status: "fulfilled",
+			value: { habits: [{ id: target.id }] },
+		});
+		if (homeResult.status === "fulfilled") {
+			expect(getActivity(homeResult.value, "2026-07-10").completionRate).toBe(
+				1,
+			);
+		}
+		expect(archiveResult).toMatchObject({ status: "fulfilled" });
+		const [stored] = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.id, target.id));
+		expect(stored.archivedAt).toEqual(now);
+	});
+
+	it("update先行時は更新後のnameとemojiをhomeへ反映する", async () => {
+		const target = await insertHabit({ currentStreak: 0 });
+		const [updateResult, homeResult] = await runHabitOperationsInOrder(
+			target.id,
+			() =>
+				updateHabit({
+					user: owner,
+					habitId: target.id,
+					body: { name: "更新後", emoji: "🌱" },
+					now,
+				}),
+			() => getHomeData({ user: owner, now }),
+		);
+
+		expect(updateResult).toMatchObject({ status: "fulfilled" });
+		expect(homeResult).toMatchObject({
+			status: "fulfilled",
+			value: { habits: [{ name: "更新後", emoji: "🌱" }] },
+		});
+	});
+
+	it("update待機中にname順が逆転しても更新後の値で再ソートする", async () => {
+		const target = await insertHabit({ name: "a", currentStreak: 0 });
+		await insertHabit({ name: "b", currentStreak: 0 });
+		const [updateResult, homeResult] = await runHabitOperationsInOrder(
+			target.id,
+			() =>
+				updateHabit({
+					user: owner,
+					habitId: target.id,
+					body: { name: "z", emoji: "🌱" },
+					now,
+				}),
+			() => getHomeData({ user: owner, now }),
+		);
+
+		expect(updateResult).toMatchObject({ status: "fulfilled" });
+		expect(homeResult).toMatchObject({ status: "fulfilled" });
+		if (homeResult.status === "fulfilled") {
+			expect(homeResult.value.habits.map((item) => item.name)).toEqual([
+				"b",
+				"z",
+			]);
+		}
+	});
+
+	it("home先行時は固定したnameを返した後にupdateを成立させる", async () => {
+		const target = await insertHabit({ currentStreak: 0 });
+		const [homeResult, updateResult] = await runHabitOperationsInOrder(
+			target.id,
+			() => getHomeData({ user: owner, now }),
+			() =>
+				updateHabit({
+					user: owner,
+					habitId: target.id,
+					body: { name: "更新後", emoji: "🌱" },
+					now,
+				}),
+		);
+
+		expect(homeResult).toMatchObject({
+			status: "fulfilled",
+			value: { habits: [{ name: "読書", emoji: "📚" }] },
+		});
+		expect(updateResult).toMatchObject({ status: "fulfilled" });
+		const [stored] = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.id, target.id));
+		expect(stored).toMatchObject({ name: "更新後", emoji: "🌱" });
+	});
+});

--- a/web-app/src/features/home/home.service.server.ts
+++ b/web-app/src/features/home/home.service.server.ts
@@ -1,11 +1,182 @@
+import { and, asc, eq, gte, inArray, isNull, lte, max } from "drizzle-orm";
+import { db } from "~/db/index.server";
+import { dailyRecord, habit } from "~/db/schema";
 import type { AuthenticatedUser } from "~/lib/api/auth.server";
-import { notImplementedApiError } from "~/lib/api/errors";
+import {
+	addDaysToJstDateString,
+	getJstDateContext,
+	getJstDateStart,
+} from "~/lib/api/date";
 
 export type GetHomeDataInput = {
 	user: AuthenticatedUser;
 	now?: Date;
 };
 
-export async function getHomeData(_input: GetHomeDataInput): Promise<never> {
-	throw notImplementedApiError("GET /api/home");
+export type HomeDataResponse = {
+	habits: Array<{
+		id: string;
+		name: string;
+		emoji: string;
+		currentStreak: number;
+		maxStreak: number;
+		isCompletedToday: boolean;
+	}>;
+	activityLog: Array<{
+		date: string;
+		completionRate: number | null;
+	}>;
+};
+
+const ACTIVITY_LOG_DAYS = 365;
+
+function getActivityLogDates(today: string): string[] {
+	const oldest = addDaysToJstDateString(today, -(ACTIVITY_LOG_DAYS - 1));
+	return Array.from({ length: ACTIVITY_LOG_DAYS }, (_, index) =>
+		addDaysToJstDateString(oldest, index),
+	);
+}
+
+export async function getHomeData(
+	input: GetHomeDataInput,
+): Promise<HomeDataResponse> {
+	const now = input.now ?? new Date();
+	const { today, yesterday } = getJstDateContext(now);
+	const activityDates = getActivityLogDates(today);
+	const oldestActivityDate = activityDates[0];
+
+	return db.transaction(async (tx) => {
+		// complete / update / archive と同じ habit 行ロックで active 集合を固定する。
+		// name 更新との競合時にもロック順が変わらないよう、まず id 順でロックする。
+		const lockedHabitIdRows = await tx
+			.select({ id: habit.id })
+			.from(habit)
+			.where(and(eq(habit.userId, input.user.id), isNull(habit.archivedAt)))
+			.orderBy(asc(habit.id))
+			.for("update");
+
+		const habitIds = lockedHabitIdRows.map((row) => row.id);
+		if (habitIds.length === 0) {
+			return {
+				habits: [],
+				activityLog: activityDates.map((date) => ({
+					date,
+					completionRate: null,
+				})),
+			};
+		}
+
+		// READ COMMITTED では ORDER BY 後の行ロック待機中にソートキーが更新されると、
+		// 更新後の値が更新前の位置で返り得る。固定済み ID をロック取得後に再取得し、
+		// DB の collation で仕様順を確定する。
+		const lockedHabits = await tx
+			.select()
+			.from(habit)
+			.where(
+				and(
+					eq(habit.userId, input.user.id),
+					inArray(habit.id, habitIds),
+					isNull(habit.archivedAt),
+				),
+			)
+			.orderBy(asc(habit.name), asc(habit.createdAt), asc(habit.id));
+		if (lockedHabits.length !== habitIds.length) {
+			throw new Error("固定した習慣を取得できませんでした。");
+		}
+
+		const latestRecordRows = await tx
+			.select({
+				habitId: dailyRecord.habitId,
+				date: max(dailyRecord.date),
+			})
+			.from(dailyRecord)
+			.where(inArray(dailyRecord.habitId, habitIds))
+			.groupBy(dailyRecord.habitId);
+		const latestDateByHabitId = new Map(
+			latestRecordRows.map((row) => [row.habitId, row.date]),
+		);
+
+		const expiredHabitIds = lockedHabits
+			.filter((row) => {
+				const latestDate = latestDateByHabitId.get(row.id);
+				return (
+					row.currentStreak > 0 &&
+					(latestDate === undefined ||
+						latestDate === null ||
+						latestDate < yesterday)
+				);
+			})
+			.map((row) => row.id);
+
+		if (expiredHabitIds.length > 0) {
+			const resetHabits = await tx
+				.update(habit)
+				.set({ currentStreak: 0, updatedAt: now })
+				.where(
+					and(
+						eq(habit.userId, input.user.id),
+						inArray(habit.id, expiredHabitIds),
+						isNull(habit.archivedAt),
+					),
+				)
+				.returning({ id: habit.id });
+			if (resetHabits.length !== expiredHabitIds.length) {
+				throw new Error("ストリークの補正結果を取得できませんでした。");
+			}
+		}
+		const expiredHabitIdSet = new Set(expiredHabitIds);
+
+		const activityRecords = await tx
+			.select({ habitId: dailyRecord.habitId, date: dailyRecord.date })
+			.from(dailyRecord)
+			.where(
+				and(
+					inArray(dailyRecord.habitId, habitIds),
+					gte(dailyRecord.date, oldestActivityDate),
+					lte(dailyRecord.date, today),
+				),
+			);
+		const completedHabitIdsByDate = new Map<string, Set<string>>();
+		for (const record of activityRecords) {
+			const completedHabitIds =
+				completedHabitIdsByDate.get(record.date) ?? new Set<string>();
+			completedHabitIds.add(record.habitId);
+			completedHabitIdsByDate.set(record.date, completedHabitIds);
+		}
+
+		const completedToday = completedHabitIdsByDate.get(today) ?? new Set();
+		return {
+			habits: lockedHabits.map((row) => ({
+				id: row.id,
+				name: row.name,
+				emoji: row.emoji,
+				currentStreak: expiredHabitIdSet.has(row.id) ? 0 : row.currentStreak,
+				maxStreak: row.maxStreak,
+				isCompletedToday: completedToday.has(row.id),
+			})),
+			activityLog: activityDates.map((date) => {
+				if (date === today) {
+					return { date, completionRate: null };
+				}
+
+				const dayEnd = getJstDateStart(addDaysToJstDateString(date, 1));
+				const targetHabits = lockedHabits.filter(
+					(row) => row.createdAt < dayEnd,
+				);
+				if (targetHabits.length === 0) {
+					return { date, completionRate: null };
+				}
+
+				const completedHabitIds =
+					completedHabitIdsByDate.get(date) ?? new Set();
+				const completedCount = targetHabits.filter((row) =>
+					completedHabitIds.has(row.id),
+				).length;
+				return {
+					date,
+					completionRate: completedCount / targetHabits.length,
+				};
+			}),
+		};
+	});
 }

--- a/web-app/src/features/home/home.service.test.ts
+++ b/web-app/src/features/home/home.service.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "~/db/index.server";
+import type { AuthenticatedUser } from "~/lib/api/auth.server";
+import { getHomeData } from "./home.service.server";
+
+vi.mock("~/db/index.server", () => ({
+	db: { transaction: vi.fn() },
+}));
+
+const transactionMock = vi.mocked(db.transaction);
+const user = { id: "test-user" } as AuthenticatedUser;
+
+describe("getHomeData", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it("transaction失敗時に補正前データへフォールバックしない", async () => {
+		transactionMock.mockRejectedValueOnce(new Error("database unavailable"));
+
+		await expect(
+			getHomeData({
+				user,
+				now: new Date("2026-07-12T03:00:00.000Z"),
+			}),
+		).rejects.toThrow("database unavailable");
+	});
+
+	it("habit件数に依存せず固定回数の一括SELECTで取得する", async () => {
+		const activeHabits = Array.from({ length: 10 }, (_, index) => ({
+			id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+			userId: user.id,
+			name: `habit-${index}`,
+			emoji: "",
+			currentStreak: 0,
+			maxStreak: 0,
+			archivedAt: null,
+			createdAt: new Date("2026-07-01T03:00:00.000Z"),
+			updatedAt: new Date("2026-07-01T03:00:00.000Z"),
+		}));
+		const lockHabits = vi.fn().mockResolvedValue(activeHabits);
+		const selectLockedHabits = vi.fn().mockResolvedValue(activeHabits);
+		const groupLatestRecords = vi.fn().mockResolvedValue([]);
+		const selectActivityRecords = vi.fn().mockResolvedValue([]);
+		const select = vi
+			.fn()
+			.mockReturnValueOnce({
+				from: () => ({
+					where: () => ({
+						orderBy: () => ({ for: lockHabits }),
+					}),
+				}),
+			})
+			.mockReturnValueOnce({
+				from: () => ({
+					where: () => ({ orderBy: selectLockedHabits }),
+				}),
+			})
+			.mockReturnValueOnce({
+				from: () => ({
+					where: () => ({ groupBy: groupLatestRecords }),
+				}),
+			})
+			.mockReturnValueOnce({
+				from: () => ({ where: selectActivityRecords }),
+			});
+		const fakeTx = { select };
+		transactionMock.mockImplementationOnce(async (callback) =>
+			callback(fakeTx as never),
+		);
+
+		const result = await getHomeData({
+			user,
+			now: new Date("2026-07-12T03:00:00.000Z"),
+		});
+
+		expect(result.habits).toHaveLength(10);
+		expect(select).toHaveBeenCalledTimes(4);
+		expect(lockHabits).toHaveBeenCalledTimes(1);
+		expect(selectLockedHabits).toHaveBeenCalledTimes(1);
+		expect(groupLatestRecords).toHaveBeenCalledTimes(1);
+		expect(selectActivityRecords).toHaveBeenCalledTimes(1);
+	});
+});

--- a/web-app/src/lib/api/date.test.ts
+++ b/web-app/src/lib/api/date.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	addDaysToJstDateString,
 	getJstDateContext,
+	getJstDateStart,
 	toJstDateString,
 	toJstDateTimeString,
 } from "./date";
@@ -29,5 +30,11 @@ describe("JST date utilities", () => {
 	it("JST 日付文字列に日数を加算できる", () => {
 		expect(addDaysToJstDateString("2024-02-28", 1)).toBe("2024-02-29");
 		expect(addDaysToJstDateString("2024-03-01", -1)).toBe("2024-02-29");
+	});
+
+	it("JSTの日付開始を絶対時刻へ変換する", () => {
+		expect(getJstDateStart("2026-07-12").toISOString()).toBe(
+			"2026-07-11T15:00:00.000Z",
+		);
 	});
 });

--- a/web-app/src/lib/api/date.ts
+++ b/web-app/src/lib/api/date.ts
@@ -61,3 +61,8 @@ export function addDaysToJstDateString(date: string, days: number): string {
 	utcDate.setUTCDate(utcDate.getUTCDate() + days);
 	return utcDate.toISOString().slice(0, 10);
 }
+
+export function getJstDateStart(date: string): Date {
+	const [year, month, day] = date.split("-").map(Number);
+	return new Date(Date.UTC(year, month - 1, day) - 9 * 60 * 60 * 1000);
+}

--- a/web-app/src/lib/api/route.server.ts
+++ b/web-app/src/lib/api/route.server.ts
@@ -8,12 +8,13 @@ export function handleAuthenticatedApi<TResult>(
 			Awaited<ReturnType<typeof requireAuthenticatedUser>>
 		>,
 	) => TResult | Response | Promise<TResult | Response>,
-	options: { successStatus?: number } = {},
+	options: { successStatus?: number; successHeaders?: HeadersInit } = {},
 ): Promise<Response> {
 	return handleApiRequest({
 		request,
 		authenticate: requireAuthenticatedUser,
 		handler,
 		successStatus: options.successStatus,
+		successHeaders: options.successHeaders,
 	});
 }

--- a/web-app/src/lib/api/route.test.ts
+++ b/web-app/src/lib/api/route.test.ts
@@ -29,6 +29,18 @@ describe("handleApiRequest", () => {
 		expect(await response.json()).toEqual({ userId: "user_1" });
 	});
 
+	it("成功レスポンスへ指定されたheadersを付与する", async () => {
+		const response = await handleApiRequest({
+			request: new Request("http://localhost/api/home"),
+			authenticate: async () => ({ id: "user_1" }),
+			handler: async () => ({ habits: [], activityLog: [] }),
+			successHeaders: { "cache-control": "no-store" },
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("cache-control")).toBe("no-store");
+	});
+
 	it("immutableなheadersを持つResponseにもrequest IDを付与する", async () => {
 		const response = await handleApiRequest({
 			request: new Request("http://localhost/api/home"),

--- a/web-app/src/lib/api/route.ts
+++ b/web-app/src/lib/api/route.ts
@@ -13,6 +13,7 @@ type HandleApiRequestOptions<TUser, TResult> = {
 		context: ApiRequestContext<TUser>,
 	) => TResult | Response | Promise<TResult | Response>;
 	successStatus?: number;
+	successHeaders?: HeadersInit;
 };
 
 const uuidPattern =
@@ -45,6 +46,7 @@ export async function handleApiRequest<TUser, TResult>({
 	authenticate,
 	handler,
 	successStatus = 200,
+	successHeaders,
 }: HandleApiRequestOptions<TUser, TResult>): Promise<Response> {
 	const requestId = resolveRequestId(request);
 	const startedAt = performance.now();
@@ -65,7 +67,10 @@ export async function handleApiRequest<TUser, TResult>({
 		if (result instanceof Response) {
 			response = result;
 		} else {
-			response = jsonResponse(result, { status: successStatus });
+			response = jsonResponse(result, {
+				status: successStatus,
+				headers: successHeaders,
+			});
 		}
 	} catch (error) {
 		caughtError = error;

--- a/web-app/src/routes/api/home.ts
+++ b/web-app/src/routes/api/home.ts
@@ -6,7 +6,9 @@ export const Route = createFileRoute("/api/home")({
 	server: {
 		handlers: {
 			GET: ({ request }) =>
-				handleAuthenticatedApi(request, ({ user }) => getHomeData({ user })),
+				handleAuthenticatedApi(request, ({ user }) => getHomeData({ user }), {
+					successHeaders: { "cache-control": "no-store" },
+				}),
 		},
 	},
 });


### PR DESCRIPTION
## 概要

ホーム画面に必要な active habit 一覧と直近365日の Activity Log を返す `GET /api/home` を実装しました。

Closes #32
Closes #35

## 変更内容

- active habit を `name → createdAt → id` で安定ソートして返却
- `isCompletedToday` を JST の当日 `daily_record` から算出
- JST の今日を含む365日を oldest → newest で生成
- 表示時点の active habit と `createdAt < D+1 00:00 JST` に基づき Activity Log を再集計
- 今日と過去日の分母0を `completionRate: null` として返却
- archive 後の habit を過去日の分子・分母からも除外
- 成功レスポンスへ `Cache-Control: no-store` を付与

## Lazy Update と排他制御

- active habit ID を `id` 順に一括 `FOR UPDATE` して固定
- ロック後の固定 ID を DB collation の `name → createdAt → id` で再取得
- 直近達成日を `MAX(date) GROUP BY habitId` で一括取得
- `currentStreak > 0` かつ直近達成日がない、または昨日より前の habit だけを一括で0へ補正
- complete / archive / update と同じ habit 行ロックで直列化し、成立済み更新を stale write で上書きしない
- habit 件数に依存しない最大5 DB statements で処理

## 競合テスト

- complete → home: 当日 record と streak を保持
- home → complete: 補正後に streak を1で開始
- archive → home / home → archive
- update → home / home → update
- update 待機中に name 順が逆転しても、更新後の値で再ソート

外部 blocker transaction と PostgreSQL のロック待機状態を使い、各取得順を固定して検証しています。

## 検証

- `pnpm test`（86件成功）
- `pnpm run test:integration`（39件成功）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run build`
