### PR TITLE
MVP APIの索引と競合テストを強化

### DIFF
--- a/web-app/drizzle/0003_thick_warhawk.sql
+++ b/web-app/drizzle/0003_thick_warhawk.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "habit_user_id_archived_at_id_idx" ON "habit" USING btree ("userId","archivedAt","id");

--- a/web-app/drizzle/meta/0003_snapshot.json
+++ b/web-app/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,479 @@
+{
+	"id": "ee3681b6-70a6-466d-87b5-4217ef4dcb59",
+	"prevId": "1e1847d0-d290-4ead-a7f8-8041f475f672",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"providerId": {
+					"name": "providerId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"accessToken": {
+					"name": "accessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refreshToken": {
+					"name": "refreshToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"idToken": {
+					"name": "idToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accessTokenExpiresAt": {
+					"name": "accessTokenExpiresAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refreshTokenExpiresAt": {
+					"name": "refreshTokenExpiresAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_userId_user_id_fk": {
+					"name": "account_userId_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.daily_record": {
+			"name": "daily_record",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"habitId": {
+					"name": "habitId",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completedAt": {
+					"name": "completedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"daily_record_habitId_habit_id_fk": {
+					"name": "daily_record_habitId_habit_id_fk",
+					"tableFrom": "daily_record",
+					"tableTo": "habit",
+					"columnsFrom": ["habitId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"habit_date_unique": {
+					"name": "habit_date_unique",
+					"nullsNotDistinct": false,
+					"columns": ["habitId", "date"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.habit": {
+			"name": "habit",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"emoji": {
+					"name": "emoji",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"currentStreak": {
+					"name": "currentStreak",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"maxStreak": {
+					"name": "maxStreak",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"archivedAt": {
+					"name": "archivedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"habit_user_id_archived_at_id_idx": {
+					"name": "habit_user_id_archived_at_id_idx",
+					"columns": [
+						{
+							"expression": "userId",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "archivedAt",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"habit_userId_user_id_fk": {
+					"name": "habit_userId_user_id_fk",
+					"tableFrom": "habit",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ipAddress": {
+					"name": "ipAddress",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"userAgent": {
+					"name": "userAgent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"session_userId_user_id_fk": {
+					"name": "session_userId_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timezone": {
+					"name": "timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'Asia/Tokyo'"
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/web-app/drizzle/meta/_journal.json
+++ b/web-app/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
 			"when": 1783836036871,
 			"tag": "0002_bright_mathemanic",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1786181165724,
+			"tag": "0003_thick_warhawk",
+			"breakpoints": true
 		}
 	]
 }

--- a/web-app/src/db/schema.ts
+++ b/web-app/src/db/schema.ts
@@ -1,6 +1,7 @@
 import {
 	boolean,
 	date,
+	index,
 	integer,
 	pgTable,
 	text,
@@ -106,23 +107,33 @@ export const verification = pgTable("verification", {
 // 2. アプリ固有のテーブル (Daily Green)
 // ==========================================
 
-export const habit = pgTable("habit", {
-	id: uuid("id").primaryKey().defaultRandom(),
-	userId: text("userId")
-		.notNull()
-		.references(() => user.id, { onDelete: "cascade" }),
-	name: text("name").notNull(),
-	emoji: text("emoji").notNull().default(""),
-	currentStreak: integer("currentStreak").notNull().default(0),
-	maxStreak: integer("maxStreak").notNull().default(0),
-	archivedAt: timestamp("archivedAt", { mode: "date", withTimezone: true }),
-	createdAt: timestamp("createdAt", { mode: "date", withTimezone: true })
-		.notNull()
-		.defaultNow(),
-	updatedAt: timestamp("updatedAt", { mode: "date", withTimezone: true })
-		.notNull()
-		.defaultNow(),
-});
+export const habit = pgTable(
+	"habit",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		userId: text("userId")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		name: text("name").notNull(),
+		emoji: text("emoji").notNull().default(""),
+		currentStreak: integer("currentStreak").notNull().default(0),
+		maxStreak: integer("maxStreak").notNull().default(0),
+		archivedAt: timestamp("archivedAt", { mode: "date", withTimezone: true }),
+		createdAt: timestamp("createdAt", { mode: "date", withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		updatedAt: timestamp("updatedAt", { mode: "date", withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(table) => [
+		index("habit_user_id_archived_at_id_idx").on(
+			table.userId,
+			table.archivedAt,
+			table.id,
+		),
+	],
+);
 
 export const dailyRecord = pgTable(
 	"daily_record",

--- a/web-app/src/features/habits/complete-habit.integration.test.ts
+++ b/web-app/src/features/habits/complete-habit.integration.test.ts
@@ -1,4 +1,4 @@
-import { and, count, eq } from "drizzle-orm";
+import { and, count, eq, sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { db } from "~/db/index.server";
 import { dailyRecord, habit, user } from "~/db/schema";
@@ -28,6 +28,24 @@ async function insertHabit(
 		throw new Error("テスト用habitを作成できませんでした。");
 	}
 	return created;
+}
+
+function getErrorMessages(error: unknown): string[] {
+	const messages: string[] = [];
+	const visited = new Set<object>();
+	let current = error;
+	while (typeof current === "object" && current !== null) {
+		if (visited.has(current)) {
+			break;
+		}
+		visited.add(current);
+		const candidate = current as { message?: unknown; cause?: unknown };
+		if (typeof candidate.message === "string") {
+			messages.push(candidate.message);
+		}
+		current = candidate.cause;
+	}
+	return messages;
 }
 
 describe("completeHabit PostgreSQL integration", () => {
@@ -149,6 +167,69 @@ describe("completeHabit PostgreSQL integration", () => {
 		).rejects.toMatchObject({
 			code: "HABIT_ALREADY_COMPLETED_TODAY",
 			status: 409,
+		});
+	});
+
+	it("daily_record INSERT後のhabit更新失敗時にtransaction全体をrollbackする", async () => {
+		const target = await insertHabit({ currentStreak: 4, maxStreak: 7 });
+		await db.insert(dailyRecord).values({
+			habitId: target.id,
+			date: "2026-07-11",
+			completedAt: new Date("2026-07-11T03:00:00.000Z"),
+		});
+
+		try {
+			await db.execute(sql`
+				drop trigger if exists test_fail_complete_habit_update on "habit"
+			`);
+			await db.execute(sql`
+				create or replace function test_fail_complete_habit_update()
+				returns trigger
+				language plpgsql
+				as $trigger$
+				begin
+					raise exception 'forced habit update failure';
+				end;
+				$trigger$
+			`);
+			await db.execute(sql`
+				create trigger test_fail_complete_habit_update
+				before update on "habit"
+				for each row execute function test_fail_complete_habit_update()
+			`);
+
+			let failure: unknown;
+			try {
+				await completeHabit({ user: owner, habitId: target.id, now: baseNow });
+			} catch (error) {
+				failure = error;
+			}
+			expect(getErrorMessages(failure)).toContain(
+				"forced habit update failure",
+			);
+		} finally {
+			await db.execute(sql`
+				drop trigger if exists test_fail_complete_habit_update on "habit"
+			`);
+			await db.execute(sql`
+				drop function if exists test_fail_complete_habit_update()
+			`);
+		}
+
+		const records = await db
+			.select({ date: dailyRecord.date })
+			.from(dailyRecord)
+			.where(eq(dailyRecord.habitId, target.id));
+		expect(records).toEqual([{ date: "2026-07-11" }]);
+
+		const [storedHabit] = await db
+			.select()
+			.from(habit)
+			.where(eq(habit.id, target.id));
+		expect(storedHabit).toMatchObject({
+			currentStreak: 4,
+			maxStreak: 7,
+			updatedAt: baseNow,
 		});
 	});
 

--- a/web-app/src/features/habits/habits.service.integration.test.ts
+++ b/web-app/src/features/habits/habits.service.integration.test.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, isNull } from "drizzle-orm";
+import { and, count, eq, isNull, sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { db } from "~/db/index.server";
 import { habit, user } from "~/db/schema";
@@ -24,6 +24,77 @@ async function insertHabits(
 			updatedAt: now,
 		})),
 	);
+}
+
+async function waitForUserLockWaiters(expected: number): Promise<void> {
+	for (let attempt = 0; attempt < 200; attempt += 1) {
+		const result = await db.execute(sql`
+			select count(*)::int as "waiting"
+			from pg_stat_activity
+			where datname = current_database()
+				and pid <> pg_backend_pid()
+				and wait_event_type = 'Lock'
+				and query ilike '%from "user"%for update%'
+		`);
+		if (Number(result[0]?.waiting ?? 0) >= expected) {
+			return;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`user行ロックの待機数が${expected}件になりませんでした。`);
+}
+
+async function runCreatesInOrder(): Promise<
+	[
+		PromiseSettledResult<Awaited<ReturnType<typeof createHabit>>>,
+		PromiseSettledResult<Awaited<ReturnType<typeof createHabit>>>,
+	]
+> {
+	let releaseBlocker: (() => void) | undefined;
+	let notifyLocked: (() => void) | undefined;
+	const blockerRelease = new Promise<void>((resolve) => {
+		releaseBlocker = resolve;
+	});
+	const blockerLocked = new Promise<void>((resolve) => {
+		notifyLocked = resolve;
+	});
+
+	const blocker = db.transaction(async (tx) => {
+		await tx
+			.select({ id: user.id })
+			.from(user)
+			.where(eq(user.id, owner.id))
+			.for("update");
+		notifyLocked?.();
+		await blockerRelease;
+	});
+
+	await blockerLocked;
+	let firstPromise: ReturnType<typeof createHabit> | undefined;
+	let secondPromise: ReturnType<typeof createHabit> | undefined;
+	try {
+		firstPromise = createHabit({
+			user: owner,
+			body: { name: "並行1" },
+			now,
+		});
+		await waitForUserLockWaiters(1);
+		secondPromise = createHabit({
+			user: owner,
+			body: { name: "並行2" },
+			now,
+		});
+		await waitForUserLockWaiters(2);
+		releaseBlocker?.();
+		return await Promise.allSettled([firstPromise, secondPromise]);
+	} finally {
+		releaseBlocker?.();
+		await Promise.allSettled([
+			blocker,
+			...(firstPromise ? [firstPromise] : []),
+			...(secondPromise ? [secondPromise] : []),
+		]);
+	}
 }
 
 describe("createHabit PostgreSQL integration", () => {
@@ -115,5 +186,30 @@ describe("createHabit PostgreSQL integration", () => {
 			.from(habit)
 			.where(and(eq(habit.userId, owner.id), isNull(habit.archivedAt)));
 		expect(activeCount.value).toBe(10);
+	});
+
+	it("archived 999件からの並行作成を固定順に直列化して総数上限を超えない", async () => {
+		await insertHabits(999, { archived: true });
+
+		const [first, second] = await runCreatesInOrder();
+
+		expect(first).toMatchObject({
+			status: "fulfilled",
+			value: { name: "並行1" },
+		});
+		expect(second.status).toBe("rejected");
+		if (second.status === "rejected") {
+			expect(second.reason).toBeInstanceOf(ApiError);
+			expect(second.reason).toMatchObject({
+				code: "HABIT_LIMIT_EXCEEDED",
+				status: 409,
+			});
+		}
+
+		const [totalCount] = await db
+			.select({ value: count() })
+			.from(habit)
+			.where(eq(habit.userId, owner.id));
+		expect(totalCount.value).toBe(1000);
 	});
 });

--- a/web-app/src/features/home/home.service.integration.test.ts
+++ b/web-app/src/features/home/home.service.integration.test.ts
@@ -5,6 +5,7 @@ import { dailyRecord, habit, user } from "~/db/schema";
 import {
 	archiveHabit,
 	completeHabit,
+	createHabit,
 	updateHabit,
 } from "~/features/habits/habits.service.server";
 import type { AuthenticatedUser } from "~/lib/api/auth.server";
@@ -290,6 +291,55 @@ describe("getHomeData PostgreSQL integration", () => {
 		const afterAll = await getHomeData({ user: owner, now });
 		expect(afterAll.habits).toEqual([]);
 		expect(getActivity(afterAll, "2026-07-10").completionRate).toBeNull();
+	});
+
+	it("active行ロック待機中のcreateを固定集合から除外し次回取得で反映する", async () => {
+		const target = await insertHabit({ name: "a-existing" });
+		await insertRecord(target.id, "2026-07-11");
+
+		let releaseBlocker: (() => void) | undefined;
+		let notifyLocked: (() => void) | undefined;
+		const blockerRelease = new Promise<void>((resolve) => {
+			releaseBlocker = resolve;
+		});
+		const blockerLocked = new Promise<void>((resolve) => {
+			notifyLocked = resolve;
+		});
+		const blocker = db.transaction(async (tx) => {
+			await tx
+				.select({ id: habit.id })
+				.from(habit)
+				.where(eq(habit.id, target.id))
+				.for("update");
+			notifyLocked?.();
+			await blockerRelease;
+		});
+
+		await blockerLocked;
+		const waitingHome = getHomeData({ user: owner, now });
+		try {
+			await waitForHabitLockWaiters(1);
+			const created = await createHabit({
+				user: owner,
+				body: { name: "z-created" },
+				now: new Date("2026-07-01T03:00:00.000Z"),
+			});
+			releaseBlocker?.();
+
+			const fixedResult = await waitingHome;
+			expect(fixedResult.habits.map((item) => item.id)).toEqual([target.id]);
+			expect(getActivity(fixedResult, "2026-07-11").completionRate).toBe(1);
+
+			const nextResult = await getHomeData({ user: owner, now });
+			expect(nextResult.habits.map((item) => item.id)).toEqual([
+				target.id,
+				created.id,
+			]);
+			expect(getActivity(nextResult, "2026-07-11").completionRate).toBe(0.5);
+		} finally {
+			releaseBlocker?.();
+			await Promise.allSettled([blocker, waitingHome]);
+		}
 	});
 
 	it("complete先行時は当日recordとstreakを保持してhomeの古い補正で上書きしない", async () => {


### PR DESCRIPTION
## 概要

MVP 5 API の最終横断レビューで見つかった性能・回帰テスト上の指摘を解消します。

- `habit(userId, archivedAt, id)` の複合索引と migration を追加
- 総数1000件境界での並行 create テストを追加
- home と create の競合時に active 集合が固定されるテストを追加
- complete の record INSERT 後に habit UPDATE が失敗した場合の rollback テストを追加

## 検証

- `pnpm test`（86件）
- `pnpm run test:integration`（42件）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run db:check`
- `pnpm run db:generate`（schema driftなし）
- `pnpm run build`
- `git diff --check`

## 関連

Follow-up: #70 #76 #77 #78 #79