### PR TITLE
APIクライアント・データ取得更新基盤を実装

### DIFF
--- a/web-app/src/features/habits/habits.api-client.test.ts
+++ b/web-app/src/features/habits/habits.api-client.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	archiveHabit,
+	completeHabit,
+	createHabit,
+	updateHabit,
+} from "./habits.api-client";
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("習慣API client", () => {
+	it("create/update/archive/completeを仕様のmethod、path、bodyで送信する", async () => {
+		vi.stubGlobal(
+			"fetch",
+			fetchMock
+				.mockResolvedValueOnce(jsonResponse(habitResponse))
+				.mockResolvedValueOnce(jsonResponse(habitResponse))
+				.mockResolvedValueOnce(jsonResponse(habitResponse))
+				.mockResolvedValueOnce(jsonResponse(completeResponse)),
+		);
+
+		await createHabit({ name: "読書", emoji: "📚" });
+		await updateHabit("habit id", { name: "運動" });
+		await archiveHabit("habit id");
+		await completeHabit("habit id");
+
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			1,
+			"/api/habits",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ name: "読書", emoji: "📚" }),
+			}),
+		);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			"/api/habits/habit%20id",
+			expect.objectContaining({
+				method: "PATCH",
+				body: JSON.stringify({ name: "運動" }),
+			}),
+		);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			3,
+			"/api/habits/habit%20id/archive",
+			expect.objectContaining({ method: "PATCH", body: undefined }),
+		);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			4,
+			"/api/habits/habit%20id/complete",
+			expect.objectContaining({ method: "POST", body: undefined }),
+		);
+	});
+});
+
+const habitResponse = {
+	id: "habit id",
+	name: "読書",
+	emoji: "📚",
+	currentStreak: 1,
+	maxStreak: 1,
+	createdAt: "2026-08-08T00:00:00+09:00",
+	archivedAt: null,
+};
+const completeResponse = {
+	dailyRecord: {
+		id: "record-id",
+		habitId: "habit id",
+		date: "2026-08-08",
+		completedAt: "2026-08-08T00:00:00+09:00",
+	},
+	habit: { ...habitResponse, isCompletedToday: true },
+};
+
+function jsonResponse(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		headers: { "content-type": "application/json" },
+	});
+}

--- a/web-app/src/features/habits/habits.api-client.ts
+++ b/web-app/src/features/habits/habits.api-client.ts
@@ -1,0 +1,49 @@
+import { requestJson } from "~/lib/api/client";
+import type {
+	CompleteHabitResponse,
+	CreateHabitRequest,
+	HabitResponse,
+	UpdateHabitRequest,
+} from "./habits.api-contract";
+
+function jsonRequest(method: "POST" | "PATCH", body?: unknown): RequestInit {
+	return {
+		method,
+		headers:
+			body === undefined ? undefined : { "content-type": "application/json" },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	};
+}
+
+export function createHabit(
+	request: CreateHabitRequest,
+): Promise<HabitResponse> {
+	return requestJson<HabitResponse>(
+		"/api/habits",
+		jsonRequest("POST", request),
+	);
+}
+
+export function updateHabit(
+	habitId: string,
+	request: UpdateHabitRequest,
+): Promise<HabitResponse> {
+	return requestJson<HabitResponse>(
+		`/api/habits/${encodeURIComponent(habitId)}`,
+		jsonRequest("PATCH", request),
+	);
+}
+
+export function archiveHabit(habitId: string): Promise<HabitResponse> {
+	return requestJson<HabitResponse>(
+		`/api/habits/${encodeURIComponent(habitId)}/archive`,
+		jsonRequest("PATCH"),
+	);
+}
+
+export function completeHabit(habitId: string): Promise<CompleteHabitResponse> {
+	return requestJson<CompleteHabitResponse>(
+		`/api/habits/${encodeURIComponent(habitId)}/complete`,
+		jsonRequest("POST"),
+	);
+}

--- a/web-app/src/features/habits/habits.api-contract.ts
+++ b/web-app/src/features/habits/habits.api-contract.ts
@@ -1,0 +1,45 @@
+/** API の習慣作成リクエスト。server/client の両方から利用する。 */
+export type CreateHabitRequest = {
+	name: string;
+	emoji?: string;
+};
+
+/** server validation 後の create リクエスト。emoji は空文字に正規化済み。 */
+export type ParsedCreateHabitRequest = Required<CreateHabitRequest>;
+
+/** API の習慣更新リクエスト。server/client の両方から利用する。 */
+export type UpdateHabitRequest = {
+	name?: string;
+	emoji?: string;
+};
+
+/** create / update / archive の成功レスポンス。 */
+export type HabitResponse = {
+	id: string;
+	name: string;
+	emoji: string;
+	currentStreak: number;
+	maxStreak: number;
+	createdAt: string;
+	archivedAt: string | null;
+};
+
+/** complete 成功時にホームのカードへ反映する最小限の状態。 */
+export type CompletedHabit = {
+	id: string;
+	name: string;
+	emoji: string;
+	currentStreak: number;
+	maxStreak: number;
+	isCompletedToday: boolean;
+};
+
+export type CompleteHabitResponse = {
+	dailyRecord: {
+		id: string;
+		habitId: string;
+		date: string;
+		completedAt: string;
+	};
+	habit: CompletedHabit;
+};

--- a/web-app/src/features/habits/habits.contract.ts
+++ b/web-app/src/features/habits/habits.contract.ts
@@ -1,4 +1,13 @@
 import { ApiError } from "~/lib/api/errors";
+import type {
+	ParsedCreateHabitRequest,
+	UpdateHabitRequest,
+} from "./habits.api-contract";
+
+export type {
+	CreateHabitRequest,
+	UpdateHabitRequest,
+} from "./habits.api-contract";
 
 const graphemeSegmenter = new Intl.Segmenter("ja", {
 	granularity: "grapheme",
@@ -7,16 +16,6 @@ const graphemeSegmenter = new Intl.Segmenter("ja", {
 const emojiPattern = new RegExp("^\\p{RGI_Emoji}$", "v");
 const createHabitFields = new Set(["name", "emoji"]);
 const updateHabitFields = new Set(["name", "emoji"]);
-
-export type CreateHabitRequest = {
-	name: string;
-	emoji: string;
-};
-
-export type UpdateHabitRequest = {
-	name?: string;
-	emoji?: string;
-};
 
 function invalidRequest(cause?: unknown): never {
 	throw new ApiError("INVALID_REQUEST", undefined, { cause });
@@ -34,7 +33,9 @@ function isSingleEmojiGrapheme(value: string): boolean {
 	return emojiPattern.test(value);
 }
 
-export function parseCreateHabitRequest(body: unknown): CreateHabitRequest {
+export function parseCreateHabitRequest(
+	body: unknown,
+): ParsedCreateHabitRequest {
 	if (!isJsonObject(body)) {
 		return invalidRequest();
 	}

--- a/web-app/src/features/habits/habits.mutations.test.tsx
+++ b/web-app/src/features/habits/habits.mutations.test.tsx
@@ -54,7 +54,7 @@ describe("habit mutations", () => {
 		expect(refetchQueries).toHaveBeenCalledTimes(3);
 	});
 
-	it("completeはin-flight home queryをcancelしてから対象habitの3フィールドだけを更新する", async () => {
+	it("complete後に先行したstale GETが解決しても達成結果を上書きしない", async () => {
 		const queryClient = createQueryClient();
 		const original = structuredClone(homeData);
 		queryClient.setQueryData(homeQueryKey, original);
@@ -62,23 +62,20 @@ describe("habit mutations", () => {
 			queryKey: homeQueryKey,
 			refetchType: "none",
 		});
-		let homeRequestAborted = false;
+		let resolveStaleHome: ((response: Response) => void) | undefined;
 		vi.stubGlobal(
 			"fetch",
-			fetchMock.mockImplementation((path: string, init?: RequestInit) => {
+			fetchMock.mockImplementation((path: string) => {
 				if (path === "/api/home") {
-					return new Promise<Response>((_resolve, reject) => {
-						init?.signal?.addEventListener("abort", () => {
-							homeRequestAborted = true;
-							reject(new DOMException("Aborted", "AbortError"));
-						});
+					return new Promise<Response>((resolve) => {
+						resolveStaleHome = resolve;
 					});
 				}
 				return Promise.resolve(jsonResponse(completeResponse));
 			}),
 		);
 		const inFlightHome = queryClient.fetchQuery(
-			homeQueryOptions({ enabled: true }),
+			homeQueryOptions({ enabled: true }, queryClient),
 		);
 		void inFlightHome.catch(() => undefined);
 		await waitFor(() =>
@@ -89,8 +86,8 @@ describe("habit mutations", () => {
 		});
 
 		await result.current.mutateAsync();
-
-		expect(homeRequestAborted).toBe(true);
+		resolveStaleHome?.(jsonResponse(original));
+		await inFlightHome.catch(() => undefined);
 		const updated = queryClient.getQueryData<HomeDataResponse>(homeQueryKey);
 		expect(updated?.habits).toEqual([
 			{
@@ -104,7 +101,42 @@ describe("habit mutations", () => {
 		expect(updated?.activityLog).toBe(original.activityLog);
 	});
 
-	it("complete中に別操作が開始したhome refetchをcancelせず最終server stateを反映する", async () => {
+	it("complete単独成功は対象3フィールドだけを更新し、追加GETを行わない", async () => {
+		const queryClient = createQueryClient();
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					return Promise.resolve(jsonResponse(homeData));
+				}
+				return Promise.resolve(jsonResponse(completeResponse));
+			}),
+		);
+		const home = renderHook(
+			() => useHomeQuery({ enabled: true, userId: "user-a" }),
+			{ wrapper: wrapper(queryClient) },
+		);
+		const complete = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+		await waitFor(() => expect(home.result.current.data).toEqual(homeData));
+
+		await complete.result.current.mutateAsync();
+
+		expect(
+			fetchMock.mock.calls.filter(([path]) => path === "/api/home"),
+		).toHaveLength(1);
+		await waitFor(() =>
+			expect(home.result.current.data?.habits[0]).toEqual({
+				...homeData.habits[0],
+				isCompletedToday: true,
+				currentStreak: 2,
+				maxStreak: 4,
+			}),
+		);
+	});
+
+	it("先行mutationのrefetch中にcompleteしても、complete成功後の再同期で最終server stateを反映する", async () => {
 		const queryClient = createQueryClient();
 		const finalHome = {
 			...homeData,
@@ -127,7 +159,7 @@ describe("habit mutations", () => {
 			],
 		};
 		let resolveComplete: ((response: Response) => void) | undefined;
-		let resolveRefetch: ((response: Response) => void) | undefined;
+		let resolveFinalRefetch: ((response: Response) => void) | undefined;
 		let refetchAborted = false;
 		let homeRequestCount = 0;
 		vi.stubGlobal(
@@ -138,12 +170,16 @@ describe("habit mutations", () => {
 					if (homeRequestCount === 1) {
 						return Promise.resolve(jsonResponse(homeData));
 					}
-					return new Promise<Response>((resolve, reject) => {
-						resolveRefetch = resolve;
-						init?.signal?.addEventListener("abort", () => {
-							refetchAborted = true;
-							reject(new DOMException("Aborted", "AbortError"));
+					if (homeRequestCount === 2) {
+						return new Promise<Response>((_resolve, reject) => {
+							init?.signal?.addEventListener("abort", () => {
+								refetchAborted = true;
+								reject(new DOMException("Aborted", "AbortError"));
+							});
 						});
+					}
+					return new Promise<Response>((resolve) => {
+						resolveFinalRefetch = resolve;
 					});
 				}
 				if (path === "/api/habits/habit-1/complete") {
@@ -174,12 +210,14 @@ describe("habit mutations", () => {
 			name: "散歩",
 			emoji: "🚶",
 		});
-		await waitFor(() => expect(resolveRefetch).toBeTypeOf("function"));
+		await waitFor(() => expect(homeRequestCount).toBe(2));
+		expect(refetchAborted).toBe(false);
 		resolveComplete?.(jsonResponse(completeResponse));
 		await waitFor(() => expect(complete.result.current.isSuccess).toBe(true));
 
-		expect(refetchAborted).toBe(false);
-		resolveRefetch?.(jsonResponse(finalHome));
+		await waitFor(() => expect(homeRequestCount).toBe(3));
+		expect(refetchAborted).toBe(true);
+		resolveFinalRefetch?.(jsonResponse(finalHome));
 		await createExecution;
 		await waitFor(() => expect(home.result.current.data).toEqual(finalHome));
 	});
@@ -285,6 +323,147 @@ describe("habit mutations", () => {
 		let reset = false;
 		act(() => {
 			reset = result.current.resetStaleStateError();
+		});
+		expect(reset).toBe(false);
+	});
+
+	it("stale-state error後に同期GETがcancelされた場合はerrorをreset可能にしない", async () => {
+		const queryClient = createQueryClient();
+		let homeRequestCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string, init?: RequestInit) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					if (homeRequestCount === 1) {
+						return Promise.resolve(jsonResponse(homeData));
+					}
+					return new Promise<Response>((_resolve, reject) => {
+						init?.signal?.addEventListener("abort", () =>
+							reject(new DOMException("Aborted", "AbortError")),
+						);
+					});
+				}
+				return Promise.resolve(
+					jsonResponse(
+						{
+							code: "HABIT_ALREADY_COMPLETED_TODAY",
+							message: "達成済みです。",
+						},
+						409,
+					),
+				);
+			}),
+		);
+		renderHook(() => useHomeQuery({ enabled: true, userId: "user-a" }), {
+			wrapper: wrapper(queryClient),
+		});
+		const { result } = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+		await waitFor(() => expect(homeRequestCount).toBe(1));
+
+		await expect(result.current.mutateAsync()).rejects.toMatchObject({
+			code: "HABIT_ALREADY_COMPLETED_TODAY",
+		});
+		await waitFor(() => expect(homeRequestCount).toBe(2));
+		await queryClient.cancelQueries({ queryKey: homeQueryKey });
+		await waitFor(() =>
+			expect(result.current.error).toMatchObject({
+				code: "HABIT_ALREADY_COMPLETED_TODAY",
+			}),
+		);
+
+		let reset = false;
+		act(() => {
+			reset = result.current.resetStaleStateError();
+		});
+		expect(reset).toBe(false);
+	});
+
+	it("stale同期GET中のcomplete patchで古いGETが不採用でもerrorをreset可能にしない", async () => {
+		const queryClient = createQueryClient();
+		let homeRequestCount = 0;
+		let completeRequestCount = 0;
+		let resolveStaleHome: ((response: Response) => void) | undefined;
+		let resolveFinalHome: ((response: Response) => void) | undefined;
+		let staleHomeAborted = false;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string, init?: RequestInit) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					if (homeRequestCount === 1) {
+						return Promise.resolve(jsonResponse(homeData));
+					}
+					if (homeRequestCount === 2) {
+						return new Promise<Response>((resolve) => {
+							resolveStaleHome = resolve;
+							init?.signal?.addEventListener("abort", () => {
+								staleHomeAborted = true;
+							});
+						});
+					}
+					return new Promise<Response>((resolve) => {
+						resolveFinalHome = resolve;
+					});
+				}
+				completeRequestCount += 1;
+				return Promise.resolve(
+					completeRequestCount === 1
+						? jsonResponse(
+								{
+									code: "HABIT_ALREADY_COMPLETED_TODAY",
+									message: "達成済みです。",
+								},
+								409,
+							)
+						: jsonResponse(completeResponse),
+				);
+			}),
+		);
+		renderHook(() => useHomeQuery({ enabled: true, userId: "user-a" }), {
+			wrapper: wrapper(queryClient),
+		});
+		const stale = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+		const successful = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+		await waitFor(() => expect(homeRequestCount).toBe(1));
+
+		await expect(stale.result.current.mutateAsync()).rejects.toMatchObject({
+			code: "HABIT_ALREADY_COMPLETED_TODAY",
+		});
+		await waitFor(() => expect(homeRequestCount).toBe(2));
+		await successful.result.current.mutateAsync();
+		await waitFor(() => expect(homeRequestCount).toBe(3));
+		expect(staleHomeAborted).toBe(true);
+		resolveStaleHome?.(jsonResponse(homeData));
+		resolveFinalHome?.(
+			jsonResponse({
+				...homeData,
+				habits: [
+					{
+						...homeData.habits[0],
+						isCompletedToday: true,
+						currentStreak: 2,
+						maxStreak: 4,
+					},
+					...homeData.habits.slice(1),
+				],
+			}),
+		);
+
+		await waitFor(() =>
+			expect(stale.result.current.error).toMatchObject({
+				code: "HABIT_ALREADY_COMPLETED_TODAY",
+			}),
+		);
+		let reset = false;
+		act(() => {
+			reset = stale.result.current.resetStaleStateError();
 		});
 		expect(reset).toBe(false);
 	});

--- a/web-app/src/features/habits/habits.mutations.test.tsx
+++ b/web-app/src/features/habits/habits.mutations.test.tsx
@@ -3,7 +3,11 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HomeDataResponse } from "~/features/home/home.contract";
-import { homeQueryKey, homeQueryOptions } from "~/features/home/home.query";
+import {
+	homeQueryKey,
+	homeQueryOptions,
+	useHomeQuery,
+} from "~/features/home/home.query";
 import {
 	habitMutationKey,
 	isHabitMutationPending,
@@ -100,10 +104,193 @@ describe("habit mutations", () => {
 		expect(updated?.activityLog).toBe(original.activityLog);
 	});
 
-	it("stale-state error後はserverを正としてhomeを再取得する", async () => {
+	it("complete中に別操作が開始したhome refetchをcancelせず最終server stateを反映する", async () => {
 		const queryClient = createQueryClient();
-		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
-		const refetchQueries = vi.spyOn(queryClient, "refetchQueries");
+		const finalHome = {
+			...homeData,
+			habits: [
+				{
+					...homeData.habits[0],
+					isCompletedToday: true,
+					currentStreak: 2,
+					maxStreak: 4,
+				},
+				...homeData.habits.slice(1),
+				{
+					id: "habit-3",
+					name: "散歩",
+					emoji: "🚶",
+					currentStreak: 0,
+					maxStreak: 0,
+					isCompletedToday: false,
+				},
+			],
+		};
+		let resolveComplete: ((response: Response) => void) | undefined;
+		let resolveRefetch: ((response: Response) => void) | undefined;
+		let refetchAborted = false;
+		let homeRequestCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string, init?: RequestInit) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					if (homeRequestCount === 1) {
+						return Promise.resolve(jsonResponse(homeData));
+					}
+					return new Promise<Response>((resolve, reject) => {
+						resolveRefetch = resolve;
+						init?.signal?.addEventListener("abort", () => {
+							refetchAborted = true;
+							reject(new DOMException("Aborted", "AbortError"));
+						});
+					});
+				}
+				if (path === "/api/habits/habit-1/complete") {
+					return new Promise<Response>((resolve) => {
+						resolveComplete = resolve;
+					});
+				}
+				return Promise.resolve(jsonResponse(habitResponse));
+			}),
+		);
+		const home = renderHook(
+			() => useHomeQuery({ enabled: true, userId: "user-a" }),
+			{ wrapper: wrapper(queryClient) },
+		);
+		await waitFor(() => expect(home.result.current.data).toEqual(homeData));
+		const complete = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+		const create = renderHook(() => useCreateHabitMutation(), {
+			wrapper: wrapper(queryClient),
+		});
+
+		act(() => {
+			complete.result.current.mutate();
+		});
+		await waitFor(() => expect(resolveComplete).toBeTypeOf("function"));
+		const createExecution = create.result.current.mutateAsync({
+			name: "散歩",
+			emoji: "🚶",
+		});
+		await waitFor(() => expect(resolveRefetch).toBeTypeOf("function"));
+		resolveComplete?.(jsonResponse(completeResponse));
+		await waitFor(() => expect(complete.result.current.isSuccess).toBe(true));
+
+		expect(refetchAborted).toBe(false);
+		resolveRefetch?.(jsonResponse(finalHome));
+		await createExecution;
+		await waitFor(() => expect(home.result.current.data).toEqual(finalHome));
+	});
+
+	it("stale-state error後はactiveなGET成功時だけerrorをreset可能にする", async () => {
+		const queryClient = createQueryClient();
+		let resolveSynchronization: ((response: Response) => void) | undefined;
+		let homeRequestCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					if (homeRequestCount === 1) {
+						return Promise.resolve(jsonResponse(homeData));
+					}
+					return new Promise<Response>((resolve) => {
+						resolveSynchronization = resolve;
+					});
+				}
+				return Promise.resolve(
+					jsonResponse(
+						{
+							code: "HABIT_ALREADY_COMPLETED_TODAY",
+							message: "達成済みです。",
+						},
+						409,
+					),
+				);
+			}),
+		);
+		renderHook(() => useHomeQuery({ enabled: true, userId: "user-a" }), {
+			wrapper: wrapper(queryClient),
+		});
+		const { result } = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+		await waitFor(() => expect(homeRequestCount).toBe(1));
+
+		await expect(result.current.mutateAsync()).rejects.toMatchObject({
+			code: "HABIT_ALREADY_COMPLETED_TODAY",
+		});
+		await waitFor(() =>
+			expect(result.current.error).toMatchObject({
+				code: "HABIT_ALREADY_COMPLETED_TODAY",
+			}),
+		);
+		let reset = false;
+		act(() => {
+			reset = result.current.resetStaleStateError();
+		});
+		expect(reset).toBe(false);
+		await waitFor(() => expect(resolveSynchronization).toBeTypeOf("function"));
+		resolveSynchronization?.(jsonResponse(homeData));
+		await waitFor(() =>
+			expect(queryClient.getQueryData(homeQueryKey)).toEqual(homeData),
+		);
+		act(() => {
+			reset = result.current.resetStaleStateError();
+		});
+		expect(reset).toBe(true);
+		await waitFor(() => expect(result.current.error).toBeNull());
+	});
+
+	it("stale-state error後のGET失敗時はerrorをreset可能にしない", async () => {
+		const queryClient = createQueryClient();
+		let homeRequestCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					return Promise.resolve(
+						jsonResponse(
+							homeRequestCount === 1 ? homeData : { message: "failed" },
+							homeRequestCount === 1 ? 200 : 500,
+						),
+					);
+				}
+				return Promise.resolve(
+					jsonResponse(
+						{ code: "HABIT_NOT_FOUND", message: "見つかりません。" },
+						404,
+					),
+				);
+			}),
+		);
+		renderHook(() => useHomeQuery({ enabled: true, userId: "user-a" }), {
+			wrapper: wrapper(queryClient),
+		});
+		const { result } = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+		await waitFor(() => expect(homeRequestCount).toBe(1));
+
+		await expect(result.current.mutateAsync()).rejects.toMatchObject({
+			code: "HABIT_NOT_FOUND",
+		});
+		await waitFor(() => expect(homeRequestCount).toBe(2));
+		await waitFor(() =>
+			expect(result.current.error).toMatchObject({ status: 404 }),
+		);
+		let reset = false;
+		act(() => {
+			reset = result.current.resetStaleStateError();
+		});
+		expect(reset).toBe(false);
+	});
+
+	it("stale-state error時にactiveなhome queryがなければerrorをreset可能にしない", async () => {
+		const queryClient = createQueryClient();
 		vi.stubGlobal(
 			"fetch",
 			fetchMock.mockResolvedValueOnce(
@@ -120,14 +307,6 @@ describe("habit mutations", () => {
 		await expect(result.current.mutateAsync()).rejects.toMatchObject({
 			code: "HABIT_ALREADY_COMPLETED_TODAY",
 		});
-		expect(invalidateQueries).toHaveBeenCalledWith({
-			queryKey: homeQueryKey,
-			refetchType: "none",
-		});
-		expect(refetchQueries).toHaveBeenCalledWith({
-			queryKey: homeQueryKey,
-			type: "active",
-		});
 		await waitFor(() =>
 			expect(result.current.error).toMatchObject({
 				code: "HABIT_ALREADY_COMPLETED_TODAY",
@@ -137,8 +316,37 @@ describe("habit mutations", () => {
 		act(() => {
 			reset = result.current.resetStaleStateError();
 		});
-		expect(reset).toBe(true);
-		await waitFor(() => expect(result.current.error).toBeNull());
+		expect(reset).toBe(false);
+	});
+
+	it("mutationの401でsession callbackが失敗しても元のApiClientErrorを保持する", async () => {
+		const queryClient = createQueryClient();
+		const onUnauthorized = vi
+			.fn()
+			.mockRejectedValue(new Error("session failed"));
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse(
+					{ code: "UNAUTHORIZED", message: "ログインが必要です。" },
+					401,
+				),
+			),
+		);
+		const { result } = renderHook(
+			() => useCreateHabitMutation({ onUnauthorized }),
+			{ wrapper: wrapper(queryClient) },
+		);
+
+		await expect(
+			result.current.mutateAsync({ name: "読書", emoji: "📚" }),
+		).rejects.toMatchObject({
+			name: "ApiClientError",
+			status: 401,
+			code: "UNAUTHORIZED",
+		});
+		await waitFor(() => expect(onUnauthorized).toHaveBeenCalledTimes(1));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("同一habitのmutation keyは共通prefixでpendingを検知できる", async () => {

--- a/web-app/src/features/habits/habits.mutations.test.tsx
+++ b/web-app/src/features/habits/habits.mutations.test.tsx
@@ -1,0 +1,233 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HomeDataResponse } from "~/features/home/home.contract";
+import { homeQueryKey, homeQueryOptions } from "~/features/home/home.query";
+import {
+	habitMutationKey,
+	isHabitMutationPending,
+	useArchiveHabitMutation,
+	useCompleteHabitMutation,
+	useCreateHabitMutation,
+	useUpdateHabitMutation,
+} from "./habits.mutations";
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("habit mutations", () => {
+	it("create/update/archive成功後にhomeをinvalidateしてrefetchする", async () => {
+		const queryClient = createQueryClient();
+		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+		const refetchQueries = vi.spyOn(queryClient, "refetchQueries");
+		vi.stubGlobal(
+			"fetch",
+			fetchMock
+				.mockResolvedValueOnce(jsonResponse(habitResponse))
+				.mockResolvedValueOnce(jsonResponse(habitResponse))
+				.mockResolvedValueOnce(jsonResponse(habitResponse)),
+		);
+		const create = renderHook(() => useCreateHabitMutation(), {
+			wrapper: wrapper(queryClient),
+		});
+		const update = renderHook(() => useUpdateHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+		const archive = renderHook(() => useArchiveHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+
+		await create.result.current.mutateAsync({ name: "読書", emoji: "📚" });
+		await update.result.current.mutateAsync({ name: "運動" });
+		await archive.result.current.mutateAsync();
+
+		expect(invalidateQueries).toHaveBeenCalledTimes(3);
+		expect(refetchQueries).toHaveBeenCalledTimes(3);
+	});
+
+	it("completeはin-flight home queryをcancelしてから対象habitの3フィールドだけを更新する", async () => {
+		const queryClient = createQueryClient();
+		const original = structuredClone(homeData);
+		queryClient.setQueryData(homeQueryKey, original);
+		await queryClient.invalidateQueries({
+			queryKey: homeQueryKey,
+			refetchType: "none",
+		});
+		let homeRequestAborted = false;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string, init?: RequestInit) => {
+				if (path === "/api/home") {
+					return new Promise<Response>((_resolve, reject) => {
+						init?.signal?.addEventListener("abort", () => {
+							homeRequestAborted = true;
+							reject(new DOMException("Aborted", "AbortError"));
+						});
+					});
+				}
+				return Promise.resolve(jsonResponse(completeResponse));
+			}),
+		);
+		const inFlightHome = queryClient.fetchQuery(
+			homeQueryOptions({ enabled: true }),
+		);
+		void inFlightHome.catch(() => undefined);
+		await waitFor(() =>
+			expect(fetchMock).toHaveBeenCalledWith("/api/home", expect.anything()),
+		);
+		const { result } = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+
+		await result.current.mutateAsync();
+
+		expect(homeRequestAborted).toBe(true);
+		const updated = queryClient.getQueryData<HomeDataResponse>(homeQueryKey);
+		expect(updated?.habits).toEqual([
+			{
+				...original.habits[0],
+				isCompletedToday: true,
+				currentStreak: 2,
+				maxStreak: 4,
+			},
+			original.habits[1],
+		]);
+		expect(updated?.activityLog).toBe(original.activityLog);
+	});
+
+	it("stale-state error後はserverを正としてhomeを再取得する", async () => {
+		const queryClient = createQueryClient();
+		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+		const refetchQueries = vi.spyOn(queryClient, "refetchQueries");
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse(
+					{ code: "HABIT_ALREADY_COMPLETED_TODAY", message: "達成済みです。" },
+					409,
+				),
+			),
+		);
+		const { result } = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+
+		await expect(result.current.mutateAsync()).rejects.toMatchObject({
+			code: "HABIT_ALREADY_COMPLETED_TODAY",
+		});
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: homeQueryKey,
+			refetchType: "none",
+		});
+		expect(refetchQueries).toHaveBeenCalledWith({
+			queryKey: homeQueryKey,
+			type: "active",
+		});
+		await waitFor(() =>
+			expect(result.current.error).toMatchObject({
+				code: "HABIT_ALREADY_COMPLETED_TODAY",
+			}),
+		);
+		let reset = false;
+		act(() => {
+			reset = result.current.resetStaleStateError();
+		});
+		expect(reset).toBe(true);
+		await waitFor(() => expect(result.current.error).toBeNull());
+	});
+
+	it("同一habitのmutation keyは共通prefixでpendingを検知できる", async () => {
+		const queryClient = createQueryClient();
+		let finish: (() => void) | undefined;
+		const mutation = queryClient.getMutationCache().build(queryClient, {
+			mutationKey: habitMutationKey("habit-1", "complete"),
+			mutationFn: () =>
+				new Promise<void>((resolve) => {
+					finish = resolve;
+				}),
+		});
+
+		const execution = mutation.execute(undefined);
+		await waitFor(() => expect(finish).toBeTypeOf("function"));
+		expect(isHabitMutationPending(queryClient, "habit-1")).toBe(true);
+		expect(isHabitMutationPending(queryClient, "habit-2")).toBe(false);
+		finish?.();
+		await execution;
+		expect(habitMutationKey("habit-1", "update")).toEqual([
+			"habit",
+			"habit-1",
+			"update",
+		]);
+	});
+});
+
+const habitResponse = {
+	id: "habit-1",
+	name: "読書",
+	emoji: "📚",
+	currentStreak: 1,
+	maxStreak: 1,
+	createdAt: "2026-08-08T00:00:00+09:00",
+	archivedAt: null,
+};
+const completeResponse = {
+	dailyRecord: {
+		id: "record-1",
+		habitId: "habit-1",
+		date: "2026-08-08",
+		completedAt: "2026-08-08T00:00:00+09:00",
+	},
+	habit: {
+		id: "habit-1",
+		name: "サーバー上の名称は使わない",
+		emoji: "✅",
+		currentStreak: 2,
+		maxStreak: 4,
+		isCompletedToday: true,
+	},
+};
+const homeData: HomeDataResponse = {
+	habits: [
+		{
+			id: "habit-1",
+			name: "読書",
+			emoji: "📚",
+			currentStreak: 1,
+			maxStreak: 3,
+			isCompletedToday: false,
+		},
+		{
+			id: "habit-2",
+			name: "運動",
+			emoji: "🏃",
+			currentStreak: 3,
+			maxStreak: 3,
+			isCompletedToday: false,
+		},
+	],
+	activityLog: [{ date: "2026-08-08", completionRate: null }],
+};
+
+function createQueryClient(): QueryClient {
+	return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrapper(queryClient: QueryClient) {
+	return function QueryWrapper({ children }: PropsWithChildren) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}

--- a/web-app/src/features/habits/habits.mutations.test.tsx
+++ b/web-app/src/features/habits/habits.mutations.test.tsx
@@ -54,21 +54,21 @@ describe("habit mutations", () => {
 		expect(refetchQueries).toHaveBeenCalledTimes(3);
 	});
 
-	it("complete後に先行したstale GETが解決しても達成結果を上書きしない", async () => {
+	it("completeはAbortを無視する背景GETを停止し、追加GETなしでpatchを保持する", async () => {
 		const queryClient = createQueryClient();
 		const original = structuredClone(homeData);
 		queryClient.setQueryData(homeQueryKey, original);
-		await queryClient.invalidateQueries({
-			queryKey: homeQueryKey,
-			refetchType: "none",
-		});
 		let resolveStaleHome: ((response: Response) => void) | undefined;
+		let staleHomeAborted = false;
 		vi.stubGlobal(
 			"fetch",
-			fetchMock.mockImplementation((path: string) => {
+			fetchMock.mockImplementation((path: string, init?: RequestInit) => {
 				if (path === "/api/home") {
 					return new Promise<Response>((resolve) => {
 						resolveStaleHome = resolve;
+						init?.signal?.addEventListener("abort", () => {
+							staleHomeAborted = true;
+						});
 					});
 				}
 				return Promise.resolve(jsonResponse(completeResponse));
@@ -86,8 +86,15 @@ describe("habit mutations", () => {
 		});
 
 		await result.current.mutateAsync();
+		expect(staleHomeAborted).toBe(true);
+		expect(
+			fetchMock.mock.calls.filter(([path]) => path === "/api/home"),
+		).toHaveLength(1);
 		resolveStaleHome?.(jsonResponse(original));
 		await inFlightHome.catch(() => undefined);
+		await waitFor(() =>
+			expect(queryClient.getQueryState(homeQueryKey)?.fetchStatus).toBe("idle"),
+		);
 		const updated = queryClient.getQueryData<HomeDataResponse>(homeQueryKey);
 		expect(updated?.habits).toEqual([
 			{

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -1,0 +1,221 @@
+import {
+	type QueryClient,
+	useIsMutating,
+	useMutation,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { type RefObject, useCallback, useRef } from "react";
+import type { HomeDataResponse } from "~/features/home/home.contract";
+import {
+	clearHomeCache,
+	homeQueryKey,
+	invalidateAndRefetchHome,
+} from "~/features/home/home.query";
+import { ApiClientError } from "~/lib/api/client";
+import {
+	archiveHabit as archiveHabitRequest,
+	completeHabit as completeHabitRequest,
+	createHabit as createHabitRequest,
+	updateHabit as updateHabitRequest,
+} from "./habits.api-client";
+import type {
+	CompleteHabitResponse,
+	CreateHabitRequest,
+	UpdateHabitRequest,
+} from "./habits.api-contract";
+
+type HabitOperation = "update" | "archive" | "complete";
+
+export function habitMutationKey(habitId: string, operation: HabitOperation) {
+	return ["habit", habitId, operation] as const;
+}
+
+export function habitMutationPrefix(habitId: string) {
+	return ["habit", habitId] as const;
+}
+
+export function isHabitMutationPending(
+	queryClient: QueryClient,
+	habitId: string,
+): boolean {
+	return (
+		queryClient.isMutating({ mutationKey: habitMutationPrefix(habitId) }) > 0
+	);
+}
+
+export function useIsHabitMutationPending(habitId: string): boolean {
+	return useIsMutating({ mutationKey: habitMutationPrefix(habitId) }) > 0;
+}
+
+function isStaleStateError(error: unknown): boolean {
+	return (
+		error instanceof ApiClientError &&
+		(error.code === "HABIT_ARCHIVED" ||
+			error.code === "HABIT_NOT_FOUND" ||
+			error.code === "HABIT_ALREADY_COMPLETED_TODAY")
+	);
+}
+
+/**
+ * stale-state error は一度 UI に表示した後、再同期済みであることを確認してから
+ * 呼び出し側が明示的に消去する。通常の入力エラーや network error は消去しない。
+ */
+function useStaleStateErrorReset(
+	error: unknown,
+	reset: () => void,
+	synchronized: RefObject<boolean>,
+) {
+	return useCallback(() => {
+		if (!synchronized.current || !isStaleStateError(error)) {
+			return false;
+		}
+		reset();
+		synchronized.current = false;
+		return true;
+	}, [error, reset, synchronized]);
+}
+
+async function synchronizeMutationError(
+	queryClient: QueryClient,
+	error: unknown,
+	onUnauthorized?: () => void | Promise<void>,
+): Promise<void> {
+	if (!(error instanceof ApiClientError)) {
+		return;
+	}
+	if (error.status === 401) {
+		await clearHomeCache(queryClient);
+		await onUnauthorized?.();
+		return;
+	}
+	if (isStaleStateError(error)) {
+		await invalidateAndRefetchHome(queryClient);
+	}
+}
+
+function applyCompletedHabit(
+	queryClient: QueryClient,
+	completed: CompleteHabitResponse,
+): void {
+	queryClient.setQueryData<HomeDataResponse>(homeQueryKey, (home) => {
+		if (!home) {
+			return home;
+		}
+		return {
+			...home,
+			habits: home.habits.map((habit) =>
+				habit.id === completed.habit.id
+					? {
+							...habit,
+							isCompletedToday: completed.habit.isCompletedToday,
+							currentStreak: completed.habit.currentStreak,
+							maxStreak: completed.habit.maxStreak,
+						}
+					: habit,
+			),
+		};
+	});
+}
+
+export function useCreateHabitMutation(
+	options: { onUnauthorized?: () => void | Promise<void> } = {},
+) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationKey: ["habit", "create"],
+		mutationFn: (request: CreateHabitRequest) => createHabitRequest(request),
+		onSuccess: () => invalidateAndRefetchHome(queryClient),
+		onError: (error) =>
+			synchronizeMutationError(queryClient, error, options.onUnauthorized),
+	});
+}
+
+export function useUpdateHabitMutation(
+	habitId: string,
+	options: { onUnauthorized?: () => void | Promise<void> } = {},
+) {
+	const queryClient = useQueryClient();
+	const staleStateSynchronized = useRef(false);
+	const mutation = useMutation({
+		mutationKey: habitMutationKey(habitId, "update"),
+		mutationFn: (request: UpdateHabitRequest) =>
+			updateHabitRequest(habitId, request),
+		onSuccess: () => invalidateAndRefetchHome(queryClient),
+		onError: async (error) => {
+			staleStateSynchronized.current = false;
+			await synchronizeMutationError(
+				queryClient,
+				error,
+				options.onUnauthorized,
+			);
+			staleStateSynchronized.current = isStaleStateError(error);
+		},
+	});
+	const resetStaleStateError = useStaleStateErrorReset(
+		mutation.error,
+		mutation.reset,
+		staleStateSynchronized,
+	);
+	return { ...mutation, resetStaleStateError };
+}
+
+export function useArchiveHabitMutation(
+	habitId: string,
+	options: { onUnauthorized?: () => void | Promise<void> } = {},
+) {
+	const queryClient = useQueryClient();
+	const staleStateSynchronized = useRef(false);
+	const mutation = useMutation({
+		mutationKey: habitMutationKey(habitId, "archive"),
+		mutationFn: () => archiveHabitRequest(habitId),
+		onSuccess: () => invalidateAndRefetchHome(queryClient),
+		onError: async (error) => {
+			staleStateSynchronized.current = false;
+			await synchronizeMutationError(
+				queryClient,
+				error,
+				options.onUnauthorized,
+			);
+			staleStateSynchronized.current = isStaleStateError(error);
+		},
+	});
+	const resetStaleStateError = useStaleStateErrorReset(
+		mutation.error,
+		mutation.reset,
+		staleStateSynchronized,
+	);
+	return { ...mutation, resetStaleStateError };
+}
+
+export function useCompleteHabitMutation(
+	habitId: string,
+	options: { onUnauthorized?: () => void | Promise<void> } = {},
+) {
+	const queryClient = useQueryClient();
+	const staleStateSynchronized = useRef(false);
+	const mutation = useMutation({
+		mutationKey: habitMutationKey(habitId, "complete"),
+		mutationFn: () => completeHabitRequest(habitId),
+		onMutate: () => queryClient.cancelQueries({ queryKey: homeQueryKey }),
+		onSuccess: async (response) => {
+			// 完了前に始まった GET の古い結果で response-driven 更新を上書きさせない。
+			await queryClient.cancelQueries({ queryKey: homeQueryKey });
+			applyCompletedHabit(queryClient, response);
+		},
+		onError: async (error) => {
+			staleStateSynchronized.current = false;
+			await synchronizeMutationError(
+				queryClient,
+				error,
+				options.onUnauthorized,
+			);
+			staleStateSynchronized.current = isStaleStateError(error);
+		},
+	});
+	const resetStaleStateError = useStaleStateErrorReset(
+		mutation.error,
+		mutation.reset,
+		staleStateSynchronized,
+	);
+	return { ...mutation, resetStaleStateError };
+}

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -10,6 +10,7 @@ import {
 	clearHomeCache,
 	homeQueryKey,
 	invalidateAndRefetchHome,
+	preventStaleHomeResponses,
 } from "~/features/home/home.query";
 import { ApiClientError } from "~/lib/api/client";
 import {
@@ -126,6 +127,16 @@ function applyCompletedHabit(
 	});
 }
 
+function hasInvalidatedHomeRefetch(queryClient: QueryClient): boolean {
+	return queryClient
+		.getQueryCache()
+		.findAll({ queryKey: homeQueryKey, exact: true })
+		.some(
+			(query) =>
+				query.state.isInvalidated && query.state.fetchStatus === "fetching",
+		);
+}
+
 export function useCreateHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
@@ -208,11 +219,20 @@ export function useCompleteHabitMutation(
 	const mutation = useMutation({
 		mutationKey: habitMutationKey(habitId, "complete"),
 		mutationFn: () => completeHabitRequest(habitId),
-		onMutate: () => queryClient.cancelQueries({ queryKey: homeQueryKey }),
-		onSuccess: (response) => {
-			// onMutate で完了前の GET は停止済み。ここで再度 cancel すると、
-			// complete 中に別操作が開始した後発の server refetch を止めてしまう。
+		onMutate: () => ({
+			refetchAfterComplete: hasInvalidatedHomeRefetch(queryClient),
+		}),
+		onSuccess: (response, _variables, context) => {
+			const refetchAfterComplete =
+				context?.refetchAfterComplete || hasInvalidatedHomeRefetch(queryClient);
+			// 完了前に始まった GET は、完了レスポンスによる patch を上書きできない。
+			preventStaleHomeResponses(queryClient);
 			applyCompletedHabit(queryClient, response);
+			// create / edit / archive の再取得が完了操作と競合した場合だけ、最終
+			// server state を取り直す。通常のcomplete成功では追加GETを行わない。
+			if (refetchAfterComplete) {
+				void invalidateAndRefetchHome(queryClient);
+			}
 		},
 		onError: (error) => {
 			staleStateSynchronized.current = false;

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -10,7 +10,6 @@ import {
 	clearHomeCache,
 	homeQueryKey,
 	invalidateAndRefetchHome,
-	preventStaleHomeResponses,
 } from "~/features/home/home.query";
 import { ApiClientError } from "~/lib/api/client";
 import {
@@ -225,8 +224,9 @@ export function useCompleteHabitMutation(
 		onSuccess: (response, _variables, context) => {
 			const refetchAfterComplete =
 				context?.refetchAfterComplete || hasInvalidatedHomeRefetch(queryClient);
-			// 完了前に始まった GET は、完了レスポンスによる patch を上書きできない。
-			preventStaleHomeResponses(queryClient);
+			// cancelQueries は retryer を同期停止するため、Abortを無視するtransportの
+			// 古い応答もpatch後のcacheを上書きできない。
+			void queryClient.cancelQueries({ queryKey: homeQueryKey });
 			applyCompletedHabit(queryClient, response);
 			// create / edit / archive の再取得が完了操作と競合した場合だけ、最終
 			// server state を取り直す。通常のcomplete成功では追加GETを行わない。

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -79,18 +79,27 @@ async function synchronizeMutationError(
 	queryClient: QueryClient,
 	error: unknown,
 	onUnauthorized?: () => void | Promise<void>,
-): Promise<void> {
+): Promise<boolean> {
 	if (!(error instanceof ApiClientError)) {
-		return;
+		return false;
 	}
 	if (error.status === 401) {
-		await clearHomeCache(queryClient);
-		await onUnauthorized?.();
-		return;
+		try {
+			await clearHomeCache(queryClient);
+		} catch {
+			// 元の mutation error はセッション更新処理の失敗で置き換えない。
+		}
+		try {
+			await onUnauthorized?.();
+		} catch {
+			// UI は元の 401 を使って未認証状態へ遷移できる。
+		}
+		return false;
 	}
 	if (isStaleStateError(error)) {
-		await invalidateAndRefetchHome(queryClient);
+		return invalidateAndRefetchHome(queryClient);
 	}
+	return false;
 }
 
 function applyCompletedHabit(
@@ -125,8 +134,9 @@ export function useCreateHabitMutation(
 		mutationKey: ["habit", "create"],
 		mutationFn: (request: CreateHabitRequest) => createHabitRequest(request),
 		onSuccess: () => invalidateAndRefetchHome(queryClient),
-		onError: (error) =>
-			synchronizeMutationError(queryClient, error, options.onUnauthorized),
+		onError: (error) => {
+			void synchronizeMutationError(queryClient, error, options.onUnauthorized);
+		},
 	});
 }
 
@@ -141,14 +151,15 @@ export function useUpdateHabitMutation(
 		mutationFn: (request: UpdateHabitRequest) =>
 			updateHabitRequest(habitId, request),
 		onSuccess: () => invalidateAndRefetchHome(queryClient),
-		onError: async (error) => {
+		onError: (error) => {
 			staleStateSynchronized.current = false;
-			await synchronizeMutationError(
+			void synchronizeMutationError(
 				queryClient,
 				error,
 				options.onUnauthorized,
-			);
-			staleStateSynchronized.current = isStaleStateError(error);
+			).then((synchronized) => {
+				staleStateSynchronized.current = synchronized;
+			});
 		},
 	});
 	const resetStaleStateError = useStaleStateErrorReset(
@@ -169,14 +180,15 @@ export function useArchiveHabitMutation(
 		mutationKey: habitMutationKey(habitId, "archive"),
 		mutationFn: () => archiveHabitRequest(habitId),
 		onSuccess: () => invalidateAndRefetchHome(queryClient),
-		onError: async (error) => {
+		onError: (error) => {
 			staleStateSynchronized.current = false;
-			await synchronizeMutationError(
+			void synchronizeMutationError(
 				queryClient,
 				error,
 				options.onUnauthorized,
-			);
-			staleStateSynchronized.current = isStaleStateError(error);
+			).then((synchronized) => {
+				staleStateSynchronized.current = synchronized;
+			});
 		},
 	});
 	const resetStaleStateError = useStaleStateErrorReset(
@@ -197,19 +209,20 @@ export function useCompleteHabitMutation(
 		mutationKey: habitMutationKey(habitId, "complete"),
 		mutationFn: () => completeHabitRequest(habitId),
 		onMutate: () => queryClient.cancelQueries({ queryKey: homeQueryKey }),
-		onSuccess: async (response) => {
-			// 完了前に始まった GET の古い結果で response-driven 更新を上書きさせない。
-			await queryClient.cancelQueries({ queryKey: homeQueryKey });
+		onSuccess: (response) => {
+			// onMutate で完了前の GET は停止済み。ここで再度 cancel すると、
+			// complete 中に別操作が開始した後発の server refetch を止めてしまう。
 			applyCompletedHabit(queryClient, response);
 		},
-		onError: async (error) => {
+		onError: (error) => {
 			staleStateSynchronized.current = false;
-			await synchronizeMutationError(
+			void synchronizeMutationError(
 				queryClient,
 				error,
 				options.onUnauthorized,
-			);
-			staleStateSynchronized.current = isStaleStateError(error);
+			).then((synchronized) => {
+				staleStateSynchronized.current = synchronized;
+			});
 		},
 	});
 	const resetStaleStateError = useStaleStateErrorReset(

--- a/web-app/src/features/habits/habits.service.server.ts
+++ b/web-app/src/features/habits/habits.service.server.ts
@@ -4,23 +4,23 @@ import { dailyRecord, habit, user as userTable } from "~/db/schema";
 import type { AuthenticatedUser } from "~/lib/api/auth.server";
 import { getJstDateContext, toJstDateTimeString } from "~/lib/api/date";
 import { ApiError } from "~/lib/api/errors";
+import type {
+	CompletedHabit,
+	CompleteHabitResponse,
+	HabitResponse,
+} from "./habits.api-contract";
 import {
 	parseCreateHabitRequest,
 	parseUpdateHabitRequest,
 } from "./habits.contract";
 
+export type {
+	CompleteHabitResponse,
+	HabitResponse,
+} from "./habits.api-contract";
+
 const ACTIVE_HABIT_LIMIT = 10;
 const TOTAL_HABIT_LIMIT = 1000;
-
-export type HabitResponse = {
-	id: string;
-	name: string;
-	emoji: string;
-	currentStreak: number;
-	maxStreak: number;
-	createdAt: string;
-	archivedAt: string | null;
-};
 
 export type CreateHabitInput = {
 	user: AuthenticatedUser;
@@ -41,23 +41,6 @@ export type UpdateHabitInput = HabitMutationInput & {
 type HabitRow = typeof habit.$inferSelect;
 type HabitTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
-type HabitSummary = Pick<
-	HabitRow,
-	"id" | "name" | "emoji" | "currentStreak" | "maxStreak"
-> & {
-	isCompletedToday: boolean;
-};
-
-export type CompleteHabitResponse = {
-	dailyRecord: {
-		id: string;
-		habitId: string;
-		date: string;
-		completedAt: string;
-	};
-	habit: HabitSummary;
-};
-
 const uuidPattern =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -73,7 +56,7 @@ function toHabitResponse(row: HabitRow): HabitResponse {
 	};
 }
 
-function toHabitSummary(row: HabitRow): HabitSummary {
+function toHabitSummary(row: HabitRow): CompletedHabit {
 	return {
 		id: row.id,
 		name: row.name,

--- a/web-app/src/features/home/home.api-client.test.ts
+++ b/web-app/src/features/home/home.api-client.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getHomeData } from "./home.api-client";
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("getHomeData", () => {
+	it("GET /api/homeで正常取得しAbortSignalをrequestへ渡す", async () => {
+		const home = {
+			habits: [],
+			activityLog: [{ date: "2026-08-08", completionRate: null }],
+		};
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValueOnce(
+				new Response(JSON.stringify(home), {
+					headers: { "content-type": "application/json" },
+				}),
+			),
+		);
+		const controller = new AbortController();
+
+		await expect(getHomeData(controller.signal)).resolves.toEqual(home);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/home",
+			expect.objectContaining({
+				method: "GET",
+				signal: controller.signal,
+			}),
+		);
+	});
+});

--- a/web-app/src/features/home/home.api-client.ts
+++ b/web-app/src/features/home/home.api-client.ts
@@ -1,0 +1,6 @@
+import { requestJson } from "~/lib/api/client";
+import type { HomeDataResponse } from "./home.contract";
+
+export function getHomeData(signal?: AbortSignal): Promise<HomeDataResponse> {
+	return requestJson<HomeDataResponse>("/api/home", { method: "GET", signal });
+}

--- a/web-app/src/features/home/home.contract.ts
+++ b/web-app/src/features/home/home.contract.ts
@@ -1,0 +1,19 @@
+/** API の GET /api/home 成功レスポンス。server/client の両方から利用する。 */
+export type HomeHabit = {
+	id: string;
+	name: string;
+	emoji: string;
+	currentStreak: number;
+	maxStreak: number;
+	isCompletedToday: boolean;
+};
+
+export type ActivityLogEntry = {
+	date: string;
+	completionRate: number | null;
+};
+
+export type HomeDataResponse = {
+	habits: HomeHabit[];
+	activityLog: ActivityLogEntry[];
+};

--- a/web-app/src/features/home/home.day-change.test.ts
+++ b/web-app/src/features/home/home.day-change.test.ts
@@ -1,0 +1,68 @@
+import { QueryClient } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	millisecondsUntilNextJstMidnight,
+	scheduleJstMidnightRefresh,
+	useJstMidnightHomeRefresh,
+} from "./home.day-change";
+import { homeQueryKey } from "./home.query";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("JST midnight refresh", () => {
+	it("次のJST 00:00でinvalidate用callbackを実行し翌日も再予約する", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-08T14:59:59.000Z"));
+		const onMidnight = vi.fn();
+		const stop = scheduleJstMidnightRefresh(onMidnight);
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(onMidnight).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1_000);
+		expect(onMidnight).toHaveBeenCalledTimes(2);
+		stop();
+	});
+
+	it("cleanup後は予約済みtimerを実行しない", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-08T14:59:59.000Z"));
+		const onMidnight = vi.fn();
+		const stop = scheduleJstMidnightRefresh(onMidnight);
+
+		stop();
+		await vi.advanceTimersByTimeAsync(2 * 24 * 60 * 60 * 1_000);
+		expect(onMidnight).not.toHaveBeenCalled();
+	});
+
+	it("JST基準で次の00:00までの時間を算出する", () => {
+		expect(
+			millisecondsUntilNextJstMidnight(new Date("2026-08-08T14:59:59.000Z")),
+		).toBe(1_000);
+	});
+
+	it("hookはJST 00:00にhomeをinvalidateしてactive queryをrefetchする", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-08T14:59:59.000Z"));
+		const queryClient = new QueryClient();
+		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+		const refetchQueries = vi.spyOn(queryClient, "refetchQueries");
+		const { unmount } = renderHook(() =>
+			useJstMidnightHomeRefresh(queryClient, true),
+		);
+
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: homeQueryKey,
+			refetchType: "none",
+		});
+		expect(refetchQueries).toHaveBeenCalledWith({
+			queryKey: homeQueryKey,
+			type: "active",
+		});
+		unmount();
+	});
+});

--- a/web-app/src/features/home/home.day-change.test.ts
+++ b/web-app/src/features/home/home.day-change.test.ts
@@ -59,10 +59,13 @@ describe("JST midnight refresh", () => {
 			queryKey: homeQueryKey,
 			refetchType: "none",
 		});
-		expect(refetchQueries).toHaveBeenCalledWith({
-			queryKey: homeQueryKey,
-			type: "active",
-		});
+		expect(refetchQueries).toHaveBeenCalledWith(
+			{
+				queryKey: homeQueryKey,
+				type: "active",
+			},
+			{ throwOnError: true },
+		);
 		unmount();
 	});
 });

--- a/web-app/src/features/home/home.day-change.ts
+++ b/web-app/src/features/home/home.day-change.ts
@@ -1,0 +1,68 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { invalidateAndRefetchHome } from "./home.query";
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+export function millisecondsUntilNextJstMidnight(now = new Date()): number {
+	const jst = new Date(now.getTime() + JST_OFFSET_MS);
+	const nextMidnight =
+		Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), jst.getUTCDate() + 1) -
+		JST_OFFSET_MS;
+	return Math.max(1, nextMidnight - now.getTime());
+}
+
+type TimeoutId = ReturnType<typeof globalThis.setTimeout>;
+
+type TimeoutApi = {
+	setTimeout: (callback: () => void, delay: number) => TimeoutId;
+	clearTimeout: (id: TimeoutId) => void;
+};
+
+/** 次の JST 00:00 ごとに処理し、完了後に翌日の timer を予約する。 */
+export function scheduleJstMidnightRefresh(
+	onMidnight: () => void | Promise<void>,
+	options: { now?: () => Date; timers?: TimeoutApi } = {},
+): () => void {
+	const now = options.now ?? (() => new Date());
+	const timers: TimeoutApi = options.timers ?? {
+		setTimeout: (callback, delay) => globalThis.setTimeout(callback, delay),
+		clearTimeout: (id) => globalThis.clearTimeout(id),
+	};
+	let disposed = false;
+	let timerId: TimeoutId | undefined;
+
+	const schedule = () => {
+		timerId = timers.setTimeout(() => {
+			const reschedule = () => {
+				if (!disposed) {
+					schedule();
+				}
+			};
+			void Promise.resolve(onMidnight()).then(reschedule, reschedule);
+		}, millisecondsUntilNextJstMidnight(now()));
+	};
+
+	schedule();
+	return () => {
+		disposed = true;
+		if (timerId !== undefined) {
+			timers.clearTimeout(timerId);
+		}
+	};
+}
+
+/** client clock は再取得時刻の予約にのみ利用する。 */
+export function useJstMidnightHomeRefresh(
+	queryClient: QueryClient,
+	enabled: boolean,
+): void {
+	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+		return scheduleJstMidnightRefresh(() =>
+			invalidateAndRefetchHome(queryClient),
+		);
+	}, [enabled, queryClient]);
+}

--- a/web-app/src/features/home/home.day-change.ts
+++ b/web-app/src/features/home/home.day-change.ts
@@ -62,7 +62,7 @@ export function useJstMidnightHomeRefresh(
 			return;
 		}
 		return scheduleJstMidnightRefresh(() =>
-			invalidateAndRefetchHome(queryClient),
+			invalidateAndRefetchHome(queryClient).then(() => undefined),
 		);
 	}, [enabled, queryClient]);
 }

--- a/web-app/src/features/home/home.query.test.tsx
+++ b/web-app/src/features/home/home.query.test.tsx
@@ -38,7 +38,7 @@ describe("homeQueryOptions", () => {
 		expect(options.retry(0, new ApiClientError("offline"))).toBe(true);
 	});
 
-	it("401時にcacheを破棄してsession再確認callbackを呼ぶ", async () => {
+	it("401をobserverへ渡してからcacheを破棄し、session再確認callbackを呼ぶ", async () => {
 		const queryClient = createQueryClient();
 		const onUnauthorized = vi.fn();
 		vi.stubGlobal(
@@ -51,16 +51,19 @@ describe("homeQueryOptions", () => {
 			),
 		);
 
-		renderHook(
+		const { result } = renderHook(
 			() => useHomeQuery({ enabled: true, userId: "user-a", onUnauthorized }),
 			{ wrapper: wrapper(queryClient) },
 		);
 
+		await waitFor(() =>
+			expect(result.current.error).toMatchObject({ status: 401 }),
+		);
 		await waitFor(() => expect(onUnauthorized).toHaveBeenCalledTimes(1));
 		expect(queryClient.getQueryData(homeQueryKey)).toBeUndefined();
 	});
 
-	it("401時にsession callbackが失敗しても元のApiClientErrorを保持してretryしない", async () => {
+	it("401時にsession callbackが失敗してもhookは元のApiClientErrorを保持してretryしない", async () => {
 		const queryClient = createQueryClient();
 		const onUnauthorized = vi
 			.fn()
@@ -75,16 +78,27 @@ describe("homeQueryOptions", () => {
 			),
 		);
 
-		await expect(
-			queryClient.fetchQuery(
-				homeQueryOptions({ enabled: true, onUnauthorized }),
-			),
-		).rejects.toMatchObject({
+		const { result } = renderHook(
+			() => useHomeQuery({ enabled: true, userId: "user-a", onUnauthorized }),
+			{ wrapper: wrapper(queryClient) },
+		);
+
+		await waitFor(() =>
+			expect(result.current.error).toMatchObject({
+				name: "ApiClientError",
+				status: 401,
+				code: "UNAUTHORIZED",
+			}),
+		);
+		await waitFor(() => expect(onUnauthorized).toHaveBeenCalledTimes(1));
+		await expect(onUnauthorized.mock.results[0]?.value).rejects.toThrow(
+			"session failed",
+		);
+		expect(result.current.error).toMatchObject({
 			name: "ApiClientError",
 			status: 401,
 			code: "UNAUTHORIZED",
 		});
-		expect(onUnauthorized).toHaveBeenCalledTimes(1);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 

--- a/web-app/src/features/home/home.query.test.tsx
+++ b/web-app/src/features/home/home.query.test.tsx
@@ -60,6 +60,34 @@ describe("homeQueryOptions", () => {
 		expect(queryClient.getQueryData(homeQueryKey)).toBeUndefined();
 	});
 
+	it("401時にsession callbackが失敗しても元のApiClientErrorを保持してretryしない", async () => {
+		const queryClient = createQueryClient();
+		const onUnauthorized = vi
+			.fn()
+			.mockRejectedValue(new Error("session failed"));
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse(
+					{ code: "UNAUTHORIZED", message: "ログインが必要です。" },
+					401,
+				),
+			),
+		);
+
+		await expect(
+			queryClient.fetchQuery(
+				homeQueryOptions({ enabled: true, onUnauthorized }),
+			),
+		).rejects.toMatchObject({
+			name: "ApiClientError",
+			status: 401,
+			code: "UNAUTHORIZED",
+		});
+		expect(onUnauthorized).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("session identity切替中は旧homeを表示せずcacheを破棄する", async () => {
 		const queryClient = createQueryClient();
 		queryClient.setQueryData(homeQueryKey, homeData);
@@ -101,10 +129,13 @@ describe("home cache utility", () => {
 			queryKey: homeQueryKey,
 			refetchType: "none",
 		});
-		expect(refetchQueries).toHaveBeenCalledWith({
-			queryKey: homeQueryKey,
-			type: "active",
-		});
+		expect(refetchQueries).toHaveBeenCalledWith(
+			{
+				queryKey: homeQueryKey,
+				type: "active",
+			},
+			{ throwOnError: true },
+		);
 	});
 });
 

--- a/web-app/src/features/home/home.query.test.tsx
+++ b/web-app/src/features/home/home.query.test.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError } from "~/lib/api/client";
+import type { HomeDataResponse } from "./home.contract";
+import {
+	clearHomeCache,
+	homeQueryKey,
+	homeQueryOptions,
+	invalidateAndRefetchHome,
+	useHomeQuery,
+} from "./home.query";
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("homeQueryOptions", () => {
+	it("4xxはretryせずnetwork errorと5xxだけ最大1回retryする", () => {
+		const options = homeQueryOptions({ enabled: true });
+		if (typeof options.retry !== "function") {
+			throw new Error("retry function is required");
+		}
+
+		expect(options.retry(0, new ApiClientError("bad", { status: 400 }))).toBe(
+			false,
+		);
+		expect(
+			options.retry(0, new ApiClientError("server", { status: 500 })),
+		).toBe(true);
+		expect(
+			options.retry(1, new ApiClientError("server", { status: 500 })),
+		).toBe(false);
+		expect(options.retry(0, new ApiClientError("offline"))).toBe(true);
+	});
+
+	it("401時にcacheを破棄してsession再確認callbackを呼ぶ", async () => {
+		const queryClient = createQueryClient();
+		const onUnauthorized = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse(
+					{ code: "UNAUTHORIZED", message: "ログインが必要です。" },
+					401,
+				),
+			),
+		);
+
+		renderHook(
+			() => useHomeQuery({ enabled: true, userId: "user-a", onUnauthorized }),
+			{ wrapper: wrapper(queryClient) },
+		);
+
+		await waitFor(() => expect(onUnauthorized).toHaveBeenCalledTimes(1));
+		expect(queryClient.getQueryData(homeQueryKey)).toBeUndefined();
+	});
+
+	it("session identity切替中は旧homeを表示せずcacheを破棄する", async () => {
+		const queryClient = createQueryClient();
+		queryClient.setQueryData(homeQueryKey, homeData);
+		vi.stubGlobal("fetch", fetchMock.mockResolvedValue(jsonResponse(homeData)));
+		const { result, rerender } = renderHook(
+			({ userId }) => useHomeQuery({ enabled: true, userId }),
+			{ initialProps: { userId: "user-a" }, wrapper: wrapper(queryClient) },
+		);
+
+		await waitFor(() => expect(result.current.data).toEqual(homeData));
+		rerender({ userId: "user-b" });
+		expect(result.current.data).toBeUndefined();
+		await waitFor(() =>
+			expect(queryClient.getQueryData(homeQueryKey)).toBeUndefined(),
+		);
+	});
+});
+
+describe("home cache utility", () => {
+	it("logout用clearはin-flight queryをcancelしてhome cacheを削除する", async () => {
+		const queryClient = createQueryClient();
+		queryClient.setQueryData(homeQueryKey, homeData);
+		const cancelQueries = vi.spyOn(queryClient, "cancelQueries");
+
+		await clearHomeCache(queryClient);
+
+		expect(cancelQueries).toHaveBeenCalledWith({ queryKey: homeQueryKey });
+		expect(queryClient.getQueryData(homeQueryKey)).toBeUndefined();
+	});
+
+	it("invalidate後にactiveなhome queryをserverからrefetchする", async () => {
+		const queryClient = createQueryClient();
+		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+		const refetchQueries = vi.spyOn(queryClient, "refetchQueries");
+
+		await invalidateAndRefetchHome(queryClient);
+
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: homeQueryKey,
+			refetchType: "none",
+		});
+		expect(refetchQueries).toHaveBeenCalledWith({
+			queryKey: homeQueryKey,
+			type: "active",
+		});
+	});
+});
+
+const homeData: HomeDataResponse = {
+	habits: [
+		{
+			id: "habit-1",
+			name: "読書",
+			emoji: "📚",
+			currentStreak: 1,
+			maxStreak: 2,
+			isCompletedToday: false,
+		},
+	],
+	activityLog: [{ date: "2026-08-08", completionRate: null }],
+};
+
+function createQueryClient(): QueryClient {
+	return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrapper(queryClient: QueryClient) {
+	return function QueryWrapper({ children }: PropsWithChildren) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}

--- a/web-app/src/features/home/home.query.ts
+++ b/web-app/src/features/home/home.query.ts
@@ -29,7 +29,12 @@ export function homeQueryOptions({ enabled, onUnauthorized }: HomeQueryConfig) {
 				return await getHomeData(signal);
 			} catch (error) {
 				if (error instanceof ApiClientError && error.status === 401) {
-					await onUnauthorized?.();
+					// セッション更新の失敗で、API が返した 401 を別のエラーに置き換えない。
+					try {
+						await onUnauthorized?.();
+					} catch {
+						// UI は元の ApiClientError を見て未認証状態へ遷移できる。
+					}
 				}
 				throw error;
 			}
@@ -46,12 +51,26 @@ export async function clearHomeCache(queryClient: QueryClient): Promise<void> {
 /** create / edit / archive 後にサーバーのホーム状態を取り直す。 */
 export async function invalidateAndRefetchHome(
 	queryClient: QueryClient,
-): Promise<void> {
+): Promise<boolean> {
 	await queryClient.invalidateQueries({
 		queryKey: homeQueryKey,
 		refetchType: "none",
 	});
-	await queryClient.refetchQueries({ queryKey: homeQueryKey, type: "active" });
+
+	// observer がなく GET を発行していないケースは再同期済みとみなさない。
+	const hasActiveHomeQuery = queryClient
+		.getQueryCache()
+		.findAll({ queryKey: homeQueryKey, exact: true })
+		.some((query) => query.isActive());
+	try {
+		await queryClient.refetchQueries(
+			{ queryKey: homeQueryKey, type: "active" },
+			{ throwOnError: true },
+		);
+		return hasActiveHomeQuery;
+	} catch {
+		return false;
+	}
 }
 
 /**

--- a/web-app/src/features/home/home.query.ts
+++ b/web-app/src/features/home/home.query.ts
@@ -1,0 +1,100 @@
+import {
+	type QueryClient,
+	queryOptions,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiClientError, isRetryableApiError } from "~/lib/api/client";
+import { getHomeData } from "./home.api-client";
+
+export const homeQueryKey = ["home"] as const;
+
+export type HomeQueryConfig = {
+	enabled: boolean;
+	onUnauthorized?: () => void | Promise<void>;
+};
+
+export function homeQueryOptions({ enabled, onUnauthorized }: HomeQueryConfig) {
+	return queryOptions({
+		queryKey: homeQueryKey,
+		enabled,
+		staleTime: 0,
+		refetchOnWindowFocus: true,
+		refetchOnReconnect: true,
+		retry: (failureCount, error) =>
+			failureCount < 1 && isRetryableApiError(error),
+		queryFn: async ({ signal }) => {
+			try {
+				return await getHomeData(signal);
+			} catch (error) {
+				if (error instanceof ApiClientError && error.status === 401) {
+					await onUnauthorized?.();
+				}
+				throw error;
+			}
+		},
+	});
+}
+
+/** 明示ログアウト・401・セッション切替時に呼び、ユーザー間の表示漏えいを防ぐ。 */
+export async function clearHomeCache(queryClient: QueryClient): Promise<void> {
+	await queryClient.cancelQueries({ queryKey: homeQueryKey });
+	queryClient.removeQueries({ queryKey: homeQueryKey });
+}
+
+/** create / edit / archive 後にサーバーのホーム状態を取り直す。 */
+export async function invalidateAndRefetchHome(
+	queryClient: QueryClient,
+): Promise<void> {
+	await queryClient.invalidateQueries({
+		queryKey: homeQueryKey,
+		refetchType: "none",
+	});
+	await queryClient.refetchQueries({ queryKey: homeQueryKey, type: "active" });
+}
+
+/**
+ * useSession の user.id を渡して使う。identity が変わる瞬間は query data を隠し、
+ * 古いユーザーの home を新しいユーザーに表示しない。
+ */
+export function useHomeQuery(config: HomeQueryConfig & { userId?: string }) {
+	const queryClient = useQueryClient();
+	const [readyUserId, setReadyUserId] = useState(config.userId);
+	const previousUserId = useRef(config.userId);
+	const identityChanged = previousUserId.current !== config.userId;
+
+	useEffect(() => {
+		if (!identityChanged) {
+			return;
+		}
+
+		let cancelled = false;
+		previousUserId.current = config.userId;
+		void clearHomeCache(queryClient).then(() => {
+			if (!cancelled) {
+				setReadyUserId(config.userId);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [config.userId, identityChanged, queryClient]);
+
+	const onUnauthorized = useCallback(async () => {
+		await clearHomeCache(queryClient);
+		await config.onUnauthorized?.();
+	}, [config.onUnauthorized, queryClient]);
+	const query = useQuery(
+		homeQueryOptions({
+			enabled:
+				config.enabled && readyUserId === config.userId && !identityChanged,
+			onUnauthorized,
+		}),
+	);
+
+	if (readyUserId !== config.userId || identityChanged) {
+		return { ...query, data: undefined };
+	}
+	return query;
+}

--- a/web-app/src/features/home/home.query.ts
+++ b/web-app/src/features/home/home.query.ts
@@ -1,6 +1,4 @@
 import {
-	CancelledError,
-	isCancelledError,
 	type QueryClient,
 	queryOptions,
 	useQuery,
@@ -24,8 +22,8 @@ function currentHomeRequestRevision(queryClient: QueryClient): number {
 	return homeRequestRevisions.get(queryClient) ?? 0;
 }
 
-/** 進行中の古い GET 応答を採用しないための世代を進める。 */
-export function preventStaleHomeResponses(queryClient: QueryClient): number {
+/** helper ごとの正常GETを識別するための世代を進める。 */
+function advanceHomeRequestRevision(queryClient: QueryClient): number {
 	const revision = currentHomeRequestRevision(queryClient) + 1;
 	homeRequestRevisions.set(queryClient, revision);
 	return revision;
@@ -66,20 +64,13 @@ export function homeQueryOptions(
 		refetchOnWindowFocus: true,
 		refetchOnReconnect: true,
 		retry: (failureCount, error) =>
-			failureCount < 1 &&
-			!isCancelledError(error) &&
-			isRetryableApiError(error),
+			failureCount < 1 && isRetryableApiError(error),
 		queryFn: async ({ signal }) => {
 			const revision = queryClient
 				? currentHomeRequestRevision(queryClient)
 				: undefined;
 			const home = await getHomeData(signal);
-			if (queryClient && revision !== currentHomeRequestRevision(queryClient)) {
-				// 古い GET を破棄しても、mutation が直前に patch した cache を
-				// revert してはならない。
-				throw new CancelledError({ revert: false, silent: true });
-			}
-			if (queryClient) {
+			if (queryClient && !signal.aborted) {
 				recordHomeSuccessfulFetch(queryClient, revision ?? 0);
 			}
 			return home;
@@ -98,7 +89,10 @@ export async function invalidateAndRefetchHome(
 	queryClient: QueryClient,
 ): Promise<boolean> {
 	const successfulFetch = currentHomeSuccessfulFetch(queryClient);
-	const expectedRevision = preventStaleHomeResponses(queryClient);
+	const expectedRevision = advanceHomeRequestRevision(queryClient);
+	// cancelQueries は内部で同期的に query のretryerを停止する。abortを無視する
+	// transportの遅延レスポンスも、TanStack Queryの古いretryerには採用されない。
+	await queryClient.cancelQueries({ queryKey: homeQueryKey });
 	await queryClient.invalidateQueries({
 		queryKey: homeQueryKey,
 		refetchType: "none",

--- a/web-app/src/features/home/home.query.ts
+++ b/web-app/src/features/home/home.query.ts
@@ -1,4 +1,6 @@
 import {
+	CancelledError,
+	isCancelledError,
 	type QueryClient,
 	queryOptions,
 	useQuery,
@@ -10,12 +12,53 @@ import { getHomeData } from "./home.api-client";
 
 export const homeQueryKey = ["home"] as const;
 
+// A response started before a home mutation must not overwrite newer mutation
+// data if its AbortSignal is ignored by the transport.
+const homeRequestRevisions = new WeakMap<QueryClient, number>();
+const homeSuccessfulFetches = new WeakMap<
+	QueryClient,
+	{ sequence: number; revision: number }
+>();
+
+function currentHomeRequestRevision(queryClient: QueryClient): number {
+	return homeRequestRevisions.get(queryClient) ?? 0;
+}
+
+/** 進行中の古い GET 応答を採用しないための世代を進める。 */
+export function preventStaleHomeResponses(queryClient: QueryClient): number {
+	const revision = currentHomeRequestRevision(queryClient) + 1;
+	homeRequestRevisions.set(queryClient, revision);
+	return revision;
+}
+
+function currentHomeSuccessfulFetch(queryClient: QueryClient): {
+	sequence: number;
+	revision: number;
+} {
+	return (
+		homeSuccessfulFetches.get(queryClient) ?? { sequence: 0, revision: -1 }
+	);
+}
+
+function recordHomeSuccessfulFetch(
+	queryClient: QueryClient,
+	revision: number,
+): void {
+	homeSuccessfulFetches.set(queryClient, {
+		sequence: currentHomeSuccessfulFetch(queryClient).sequence + 1,
+		revision,
+	});
+}
+
 export type HomeQueryConfig = {
 	enabled: boolean;
 	onUnauthorized?: () => void | Promise<void>;
 };
 
-export function homeQueryOptions({ enabled, onUnauthorized }: HomeQueryConfig) {
+export function homeQueryOptions(
+	{ enabled }: HomeQueryConfig,
+	queryClient?: QueryClient,
+) {
 	return queryOptions({
 		queryKey: homeQueryKey,
 		enabled,
@@ -23,21 +66,23 @@ export function homeQueryOptions({ enabled, onUnauthorized }: HomeQueryConfig) {
 		refetchOnWindowFocus: true,
 		refetchOnReconnect: true,
 		retry: (failureCount, error) =>
-			failureCount < 1 && isRetryableApiError(error),
+			failureCount < 1 &&
+			!isCancelledError(error) &&
+			isRetryableApiError(error),
 		queryFn: async ({ signal }) => {
-			try {
-				return await getHomeData(signal);
-			} catch (error) {
-				if (error instanceof ApiClientError && error.status === 401) {
-					// セッション更新の失敗で、API が返した 401 を別のエラーに置き換えない。
-					try {
-						await onUnauthorized?.();
-					} catch {
-						// UI は元の ApiClientError を見て未認証状態へ遷移できる。
-					}
-				}
-				throw error;
+			const revision = queryClient
+				? currentHomeRequestRevision(queryClient)
+				: undefined;
+			const home = await getHomeData(signal);
+			if (queryClient && revision !== currentHomeRequestRevision(queryClient)) {
+				// 古い GET を破棄しても、mutation が直前に patch した cache を
+				// revert してはならない。
+				throw new CancelledError({ revert: false, silent: true });
 			}
+			if (queryClient) {
+				recordHomeSuccessfulFetch(queryClient, revision ?? 0);
+			}
+			return home;
 		},
 	});
 }
@@ -52,22 +97,31 @@ export async function clearHomeCache(queryClient: QueryClient): Promise<void> {
 export async function invalidateAndRefetchHome(
 	queryClient: QueryClient,
 ): Promise<boolean> {
+	const successfulFetch = currentHomeSuccessfulFetch(queryClient);
+	const expectedRevision = preventStaleHomeResponses(queryClient);
 	await queryClient.invalidateQueries({
 		queryKey: homeQueryKey,
 		refetchType: "none",
 	});
 
 	// observer がなく GET を発行していないケースは再同期済みとみなさない。
-	const hasActiveHomeQuery = queryClient
+	const activeHomeQueries = queryClient
 		.getQueryCache()
 		.findAll({ queryKey: homeQueryKey, exact: true })
-		.some((query) => query.isActive());
+		.filter((query) => query.isActive());
 	try {
 		await queryClient.refetchQueries(
 			{ queryKey: homeQueryKey, type: "active" },
 			{ throwOnError: true },
 		);
-		return hasActiveHomeQuery;
+		// refetchQueries は cancel された fetch でも resolve しうる。local の
+		// setQueryData では増えない、世代一致GETの完了sequenceで同期を判定する。
+		return (
+			activeHomeQueries.length > 0 &&
+			currentHomeSuccessfulFetch(queryClient).sequence >
+				successfulFetch.sequence &&
+			currentHomeSuccessfulFetch(queryClient).revision === expectedRevision
+		);
 	} catch {
 		return false;
 	}
@@ -105,12 +159,32 @@ export function useHomeQuery(config: HomeQueryConfig & { userId?: string }) {
 		await config.onUnauthorized?.();
 	}, [config.onUnauthorized, queryClient]);
 	const query = useQuery(
-		homeQueryOptions({
-			enabled:
-				config.enabled && readyUserId === config.userId && !identityChanged,
-			onUnauthorized,
-		}),
+		homeQueryOptions(
+			{
+				enabled:
+					config.enabled && readyUserId === config.userId && !identityChanged,
+			},
+			queryClient,
+		),
 	);
+	const handledUnauthorizedError = useRef<unknown>(undefined);
+
+	useEffect(() => {
+		if (
+			!(query.error instanceof ApiClientError) ||
+			query.error.status !== 401 ||
+			handledUnauthorizedError.current === query.error
+		) {
+			return;
+		}
+
+		// queryFn 内で cache を削除すると、401 が observer に届く前に query 自体を
+		// 取り除いてしまう。描画後の effect でセッションを再確認する。
+		handledUnauthorizedError.current = query.error;
+		void onUnauthorized().catch(() => {
+			// UI は元の ApiClientError を見て未認証状態へ遷移できる。
+		});
+	}, [onUnauthorized, query.error]);
 
 	if (readyUserId !== config.userId || identityChanged) {
 		return { ...query, data: undefined };

--- a/web-app/src/features/home/home.service.server.ts
+++ b/web-app/src/features/home/home.service.server.ts
@@ -7,25 +7,13 @@ import {
 	getJstDateContext,
 	getJstDateStart,
 } from "~/lib/api/date";
+import type { HomeDataResponse } from "./home.contract";
+
+export type { HomeDataResponse } from "./home.contract";
 
 export type GetHomeDataInput = {
 	user: AuthenticatedUser;
 	now?: Date;
-};
-
-export type HomeDataResponse = {
-	habits: Array<{
-		id: string;
-		name: string;
-		emoji: string;
-		currentStreak: number;
-		maxStreak: number;
-		isCompletedToday: boolean;
-	}>;
-	activityLog: Array<{
-		date: string;
-		completionRate: number | null;
-	}>;
 };
 
 const ACTIVITY_LOG_DAYS = 365;

--- a/web-app/src/lib/api/client.test.ts
+++ b/web-app/src/lib/api/client.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError, requestJson } from "./client";
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("requestJson", () => {
+	it("JSON成功レスポンスを返しAbortSignalとcookie設定を渡す", async () => {
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true })),
+		);
+		const controller = new AbortController();
+
+		await expect(
+			requestJson<{ ok: boolean }>("/api/home", { signal: controller.signal }),
+		).resolves.toEqual({
+			ok: true,
+		});
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/home",
+			expect.objectContaining({
+				credentials: "same-origin",
+				signal: controller.signal,
+			}),
+		);
+	});
+
+	it("APIエラーのcode、status、message、x-request-idを保持する", async () => {
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse(
+					{ code: "HABIT_ARCHIVED", message: "アーカイブ済みです。" },
+					409,
+					"request-123",
+				),
+			),
+		);
+
+		await expect(
+			requestJson("/api/habits/habit/complete"),
+		).rejects.toMatchObject({
+			name: "ApiClientError",
+			status: 409,
+			code: "HABIT_ARCHIVED",
+			message: "アーカイブ済みです。",
+			requestId: "request-123",
+		});
+	});
+
+	it("不正なエラーボディは安全なfallbackへ正規化する", async () => {
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValueOnce(
+				new Response("not-json", { status: 500 }),
+			),
+		);
+
+		await expect(requestJson("/api/home")).rejects.toMatchObject({
+			status: 500,
+			code: null,
+		});
+	});
+
+	it("network errorをApiClientErrorへ正規化する", async () => {
+		vi.stubGlobal(
+			"fetch",
+			fetchMock
+				.mockRejectedValueOnce(new TypeError("offline"))
+				.mockRejectedValueOnce(new TypeError("offline")),
+		);
+
+		await expect(requestJson("/api/home")).rejects.toBeInstanceOf(
+			ApiClientError,
+		);
+		await expect(requestJson("/api/home")).rejects.toMatchObject({
+			status: null,
+			code: null,
+			message: "通信に失敗しました。接続を確認して再試行してください",
+		});
+	});
+});
+
+function jsonResponse(
+	body: unknown,
+	status = 200,
+	requestId?: string,
+): Response {
+	const headers = new Headers({ "content-type": "application/json" });
+	if (requestId) {
+		headers.set("x-request-id", requestId);
+	}
+	return new Response(JSON.stringify(body), { status, headers });
+}

--- a/web-app/src/lib/api/client.test.ts
+++ b/web-app/src/lib/api/client.test.ts
@@ -67,6 +67,23 @@ describe("requestJson", () => {
 		});
 	});
 
+	it("prototype由来のcodeはAPIエラーcodeとして受理せずfallbackへ正規化する", async () => {
+		for (const code of ["toString", "constructor"]) {
+			vi.stubGlobal(
+				"fetch",
+				fetchMock.mockResolvedValueOnce(
+					jsonResponse({ code, message: "偽のエラーです。" }, 500),
+				),
+			);
+
+			await expect(requestJson("/api/home")).rejects.toMatchObject({
+				status: 500,
+				code: null,
+				message: "サーバー内部でエラーが発生しました。",
+			});
+		}
+	});
+
 	it("network errorをApiClientErrorへ正規化する", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/web-app/src/lib/api/client.ts
+++ b/web-app/src/lib/api/client.ts
@@ -1,0 +1,117 @@
+import {
+	type ApiErrorCode,
+	apiErrorMessages,
+	apiErrorStatuses,
+} from "./errors";
+
+const DEFAULT_ERROR_MESSAGE =
+	"通信に失敗しました。接続を確認して再試行してください";
+
+export class ApiClientError extends Error {
+	readonly status: number | null;
+	readonly code: ApiErrorCode | null;
+	readonly requestId: string | null;
+
+	constructor(
+		message: string,
+		options: {
+			status?: number | null;
+			code?: ApiErrorCode | null;
+			requestId?: string | null;
+			cause?: unknown;
+		} = {},
+	) {
+		super(message, { cause: options.cause });
+		this.name = "ApiClientError";
+		this.status = options.status ?? null;
+		this.code = options.code ?? null;
+		this.requestId = options.requestId ?? null;
+	}
+}
+
+function isApiErrorCode(value: unknown): value is ApiErrorCode {
+	return typeof value === "string" && value in apiErrorStatuses;
+}
+
+function isApiErrorBody(
+	value: unknown,
+): value is { code: ApiErrorCode; message: string } {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return false;
+	}
+	const body = value as Record<string, unknown>;
+	return isApiErrorCode(body.code) && typeof body.message === "string";
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+	const text = await response.text();
+	if (text === "") {
+		throw new SyntaxError("Response body is empty.");
+	}
+	return JSON.parse(text) as unknown;
+}
+
+/**
+ * API の JSON request/response を一元化する。成功レスポンスの runtime schema は
+ * API 自身を信頼し、エラーボディだけを安全に検査する。
+ */
+export async function requestJson<TResponse>(
+	path: string,
+	init: RequestInit = {},
+): Promise<TResponse> {
+	let response: Response;
+	try {
+		const headers = new Headers(init.headers);
+		if (!headers.has("accept")) {
+			headers.set("accept", "application/json");
+		}
+		response = await fetch(path, {
+			...init,
+			headers,
+			credentials: init.credentials ?? "same-origin",
+		});
+	} catch (cause) {
+		throw new ApiClientError(DEFAULT_ERROR_MESSAGE, { cause });
+	}
+
+	const requestId = response.headers.get("x-request-id");
+	let body: unknown;
+	try {
+		body = await parseJson(response);
+	} catch (cause) {
+		throw new ApiClientError(
+			response.ok
+				? "サーバーから有効なレスポンスを受け取れませんでした。"
+				: apiErrorMessages.INTERNAL_SERVER_ERROR,
+			{ status: response.status, requestId, cause },
+		);
+	}
+
+	if (!response.ok) {
+		if (isApiErrorBody(body)) {
+			throw new ApiClientError(body.message, {
+				status: response.status,
+				code: body.code,
+				requestId,
+			});
+		}
+
+		throw new ApiClientError(apiErrorMessages.INTERNAL_SERVER_ERROR, {
+			status: response.status,
+			requestId,
+		});
+	}
+
+	return body as TResponse;
+}
+
+export function isApiClientError(error: unknown): error is ApiClientError {
+	return error instanceof ApiClientError;
+}
+
+export function isRetryableApiError(error: unknown): boolean {
+	if (!isApiClientError(error)) {
+		return true;
+	}
+	return error.status === null || error.status >= 500;
+}

--- a/web-app/src/lib/api/client.ts
+++ b/web-app/src/lib/api/client.ts
@@ -30,7 +30,7 @@ export class ApiClientError extends Error {
 }
 
 function isApiErrorCode(value: unknown): value is ApiErrorCode {
-	return typeof value === "string" && value in apiErrorStatuses;
+	return typeof value === "string" && Object.hasOwn(apiErrorStatuses, value);
 }
 
 function isApiErrorBody(


### PR DESCRIPTION
## 概要

後続のMVPホームUIから共通利用するAPI clientとTanStack Queryデータ更新基盤を実装しました。

Closes #40

## 変更内容

- Home/habit API response型をclient-safe shared contractへ分離
- JSON送受信、API error、malformed response、network error、`x-request-id`、AbortSignalを扱う共通clientを追加
- `['home']` query、限定retry、focus/reconnect refetch、401/identity/logout時のcache破棄を実装
- create/edit/archive後のserver refetchと、complete成功responseによる対象habitだけのcache更新を実装
- stale-state再同期、同一habit mutation pending prefix、別habitの独立操作基盤を追加
- JST 00:00のinvalidate/refetch、翌日再予約、cleanupを実装
- client/server境界、mutation/refetch競合を含む日本語unit testsを追加

## 設計上のポイント

- client moduleから `.server.ts` やDB moduleをimportしません。
- create/edit/archiveは必ずserverからhomeを取り直します。
- completeはoptimistic updateではなく、成功responseの3フィールドだけを反映し、Activity Logは変更しません。
- home GETを世代管理し、complete成功responseより古い応答によるcache上書きを防ぎます。別mutationの再取得と競合した場合だけ、complete後にserver stateを再同期します。
- 401はquery observerへ元のAPI errorを届けてからcache破棄とsession再確認を行います。

## 確認

- `pnpm test`（15 files / 114 tests）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run test:integration` はlocalの専用 `DATABASE_URL` 未設定のため未実施。PostgreSQL付きGitHub CIを最終ゲートとします。
