### PR TITLE
Activity Logコンポーネントを実装

### DIFF
--- a/web-app/src/app.css
+++ b/web-app/src/app.css
@@ -8,9 +8,30 @@
 
 html,
 body {
-	@apply bg-white dark:bg-gray-950;
+	@apply bg-white;
+	color-scheme: light;
+}
 
-	@media (prefers-color-scheme: dark) {
-		color-scheme: dark;
-	}
+[data-activity-level="null"] {
+	background-color: #e7e5e4;
+}
+
+[data-activity-level="zero"] {
+	background-color: #cbd5d1;
+}
+
+[data-activity-level="level-1"] {
+	background-color: #bbf7d0;
+}
+
+[data-activity-level="level-2"] {
+	background-color: #86efac;
+}
+
+[data-activity-level="level-3"] {
+	background-color: #22c55e;
+}
+
+[data-activity-level="level-4"] {
+	background-color: #15803d;
 }

--- a/web-app/src/app.css
+++ b/web-app/src/app.css
@@ -13,25 +13,31 @@ body {
 }
 
 [data-activity-level="null"] {
-	background-color: #e7e5e4;
+	background-color: #f5f5f4;
+	outline-color: #d6d3d1;
 }
 
 [data-activity-level="zero"] {
-	background-color: #cbd5d1;
+	background-color: #9ca3af;
+	outline-color: #6b7280;
 }
 
 [data-activity-level="level-1"] {
-	background-color: #bbf7d0;
+	background-color: #dcfce7;
+	outline-color: #86efac;
 }
 
 [data-activity-level="level-2"] {
-	background-color: #86efac;
+	background-color: #4ade80;
+	outline-color: #22c55e;
 }
 
 [data-activity-level="level-3"] {
-	background-color: #22c55e;
+	background-color: #15803d;
+	outline-color: #166534;
 }
 
 [data-activity-level="level-4"] {
-	background-color: #15803d;
+	background-color: #052e16;
+	outline-color: #022c22;
 }

--- a/web-app/src/features/home/activity-log.test.tsx
+++ b/web-app/src/features/home/activity-log.test.tsx
@@ -25,10 +25,23 @@ describe("ActivityLog", () => {
 
 		render(<ActivityLog entries={entries} />);
 		const grid = screen.getByRole("grid", { name: "直近365日の達成率" });
+		const rows = within(grid).getAllByRole("row");
 		expect(within(grid).getAllByRole("gridcell")).toHaveLength(365);
-		expect(
-			document.querySelectorAll("[data-activity-placeholder]"),
-		).toHaveLength(6);
+		expect(rows).toHaveLength(7);
+		expect(Array.from(grid.children)).toEqual(rows);
+		for (const [index, row] of rows.entries()) {
+			expect(row).toHaveAttribute("aria-rowindex", String(index + 1));
+		}
+		const placeholders = document.querySelectorAll(
+			"[data-activity-placeholder]",
+		);
+		expect(placeholders).toHaveLength(6);
+		for (const placeholder of placeholders) {
+			expect(placeholder).toHaveAttribute("aria-hidden", "true");
+			expect(placeholder).toHaveAttribute("role", "presentation");
+			expect(placeholder).not.toHaveAttribute("aria-label");
+			expect(placeholder).not.toHaveAttribute("title");
+		}
 		expect(grid).toHaveAttribute("aria-rowcount", "7");
 		expect(grid).toHaveAttribute("aria-colcount", "53");
 	});
@@ -43,6 +56,19 @@ describe("ActivityLog", () => {
 			kind: "data",
 			entry: { date: "2024-06-01" },
 		});
+
+		render(<ActivityLog entries={entries} />);
+		const firstDataCell = screen.getByRole("gridcell", {
+			name: "2024-06-01: 未確定または対象なし",
+		});
+		expect(firstDataCell).toHaveAttribute("aria-rowindex", "7");
+		expect(firstDataCell).toHaveAttribute("aria-colindex", "1");
+		const firstRow = within(
+			screen.getByRole("grid", { name: "直近365日の達成率" }),
+		).getAllByRole("row")[0];
+		expect(firstRow).toContainElement(
+			document.querySelector('[data-activity-placeholder="true"]'),
+		);
 	});
 
 	it("null・zero・4段階の達成率境界を区別する", () => {
@@ -89,6 +115,40 @@ describe("ActivityLog", () => {
 			screen.getAllByTestId("activity-log-month-label")[0],
 		).toHaveTextContent("1月");
 		expect(screen.getByText("2月")).toBeInTheDocument();
+		expect(screen.getByTestId("activity-log-weekday-labels")).toHaveClass(
+			"mt-[13px]",
+			"h-[5.5rem]",
+			"grid-rows-[repeat(7,0.625rem)]",
+			"gap-[3px]",
+		);
+		expect(screen.getByTestId("activity-log-grid")).toHaveClass(
+			"grid-rows-[repeat(7,0.625rem)]",
+			"gap-[3px]",
+		);
+	});
+
+	it("null・zero・4段階のセルを意味別のpalette hookで描画する", () => {
+		const paletteEntries = makeEntries("2026-01-04", 365).map(
+			(entry, index) => ({
+				...entry,
+				completionRate: [null, 0, 0.25, 0.5, 0.75, 1][index % 6] ?? null,
+			}),
+		);
+		render(<ActivityLog entries={paletteEntries} />);
+
+		for (const level of [
+			"null",
+			"zero",
+			"level-1",
+			"level-2",
+			"level-3",
+			"level-4",
+		]) {
+			const cell = document.querySelector(
+				`[role="gridcell"][data-activity-level="${level}"]`,
+			);
+			expect(cell).toHaveClass("outline", "outline-1");
+		}
 	});
 
 	it("cellをTab stopやクリック可能な要素にしない", () => {

--- a/web-app/src/features/home/activity-log.test.tsx
+++ b/web-app/src/features/home/activity-log.test.tsx
@@ -1,0 +1,190 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	ActivityLog,
+	buildActivityLogWeeks,
+	getActivityLogAriaLabel,
+	getActivityLogLevel,
+	parseDateOnly,
+} from "./activity-log";
+import type { ActivityLogEntry } from "./home.contract";
+
+afterEach(() => {
+	cleanup();
+});
+
+describe("ActivityLog", () => {
+	it("365件の実データを日曜始まりの週グリッドへ、paddingを除いて表示する", () => {
+		const entries = makeEntries("2026-01-04", 365);
+		const weeks = buildActivityLogWeeks(entries);
+
+		expect(weeks).toHaveLength(53);
+		expect(weeks[0]?.cells.filter(isDataCell)).toHaveLength(7);
+		expect(weeks.at(-1)?.cells.filter(isDataCell)).toHaveLength(1);
+		expect(weeks.at(-1)?.cells.filter(isPlaceholderCell)).toHaveLength(6);
+
+		render(<ActivityLog entries={entries} />);
+		const grid = screen.getByRole("grid", { name: "直近365日の達成率" });
+		expect(within(grid).getAllByRole("gridcell")).toHaveLength(365);
+		expect(
+			document.querySelectorAll("[data-activity-placeholder]"),
+		).toHaveLength(6);
+		expect(grid).toHaveAttribute("aria-rowcount", "7");
+		expect(grid).toHaveAttribute("aria-colcount", "53");
+	});
+
+	it("先頭日が日曜以外でもUTC基準の曜日に合わせてleading paddingを置く", () => {
+		const entries = makeEntries("2024-06-01", 365);
+		const weeks = buildActivityLogWeeks(entries);
+
+		expect(parseDateOnly("2024-06-01").weekday).toBe(6);
+		expect(weeks[0]?.cells.slice(0, 6).every(isPlaceholderCell)).toBe(true);
+		expect(weeks[0]?.cells[6]).toMatchObject({
+			kind: "data",
+			entry: { date: "2024-06-01" },
+		});
+	});
+
+	it("null・zero・4段階の達成率境界を区別する", () => {
+		expect(getActivityLogLevel(null)).toBe("null");
+		expect(getActivityLogLevel(0)).toBe("zero");
+		expect(getActivityLogLevel(0.01)).toBe("level-1");
+		expect(getActivityLogLevel(0.25)).toBe("level-1");
+		expect(getActivityLogLevel(0.26)).toBe("level-2");
+		expect(getActivityLogLevel(0.5)).toBe("level-2");
+		expect(getActivityLogLevel(0.51)).toBe("level-3");
+		expect(getActivityLogLevel(0.99)).toBe("level-3");
+		expect(getActivityLogLevel(1)).toBe("level-4");
+	});
+
+	it("日本語のaria-labelとtooltipを実データにだけ付ける", () => {
+		const entries = makeEntries("2026-01-04", 365);
+		entries[0] = { date: "2026-01-04", completionRate: 0.8 };
+		entries[1] = { date: "2026-01-05", completionRate: null };
+		render(<ActivityLog entries={entries} />);
+
+		const normal = screen.getByRole("gridcell", {
+			name: "2026-01-04: 達成率 80%",
+		});
+		expect(normal).toHaveAttribute("title", "2026-01-04: 達成率 80%");
+		expect(
+			screen.getByRole("gridcell", {
+				name: "2026-01-05: 未確定または対象なし",
+			}),
+		).toBeInTheDocument();
+		expect(
+			getActivityLogAriaLabel({ date: "2026-01-06", completionRate: 0 }),
+		).toBe("2026-01-06: 達成率 0%");
+	});
+
+	it("月・曜日ラベルと日本語凡例を表示する", () => {
+		render(<ActivityLog entries={makeEntries("2026-01-04", 365)} />);
+
+		expect(screen.getByText("少ない")).toBeInTheDocument();
+		expect(screen.getByText("多い")).toBeInTheDocument();
+		expect(screen.getByText("月")).toBeInTheDocument();
+		expect(screen.getByText("水")).toBeInTheDocument();
+		expect(screen.getByText("金")).toBeInTheDocument();
+		expect(
+			screen.getAllByTestId("activity-log-month-label")[0],
+		).toHaveTextContent("1月");
+		expect(screen.getByText("2月")).toBeInTheDocument();
+	});
+
+	it("cellをTab stopやクリック可能な要素にしない", () => {
+		render(<ActivityLog entries={makeEntries("2026-01-04", 365)} />);
+
+		for (const cell of screen.getAllByRole("gridcell")) {
+			expect(cell.tagName).toBe("DIV");
+			expect(cell).not.toHaveAttribute("tabindex");
+			expect(cell).not.toHaveAttribute("role", "button");
+		}
+	});
+
+	it("mobileでは初回だけ右端へ寄せ、rerender後のユーザーscrollを維持する", () => {
+		stubMatchMedia(true);
+		const restoreScrollWidth = stubScrollWidth(720);
+		const entries = makeEntries("2026-01-04", 365);
+		const { rerender } = render(<ActivityLog entries={[]} />);
+		const scrollArea = screen.getByTestId("activity-log-scroll-area");
+
+		expect(scrollArea.scrollLeft).toBe(0);
+		rerender(<ActivityLog entries={entries} />);
+		expect(scrollArea.scrollLeft).toBe(720);
+		scrollArea.scrollLeft = 123;
+		rerender(
+			<ActivityLog
+				entries={[
+					...entries.slice(0, -1),
+					{ date: "2027-01-03", completionRate: 1 },
+				]}
+			/>,
+		);
+		expect(scrollArea.scrollLeft).toBe(123);
+		restoreScrollWidth();
+	});
+
+	it("desktopでは初期scroll位置を強制しない", () => {
+		stubMatchMedia(false);
+		const restoreScrollWidth = stubScrollWidth(720);
+		render(<ActivityLog entries={makeEntries("2026-01-04", 365)} />);
+
+		expect(screen.getByTestId("activity-log-scroll-area").scrollLeft).toBe(0);
+		restoreScrollWidth();
+	});
+});
+
+function makeEntries(startDate: string, count: number): ActivityLogEntry[] {
+	const start = parseDateOnly(startDate);
+	return Array.from({ length: count }, (_, index) => {
+		const date = new Date(
+			Date.UTC(start.year, start.month - 1, start.day + index),
+		);
+		return {
+			date: date.toISOString().slice(0, 10),
+			completionRate: index % 5 === 0 ? null : (index % 4) / 4,
+		};
+	});
+}
+
+function isDataCell(
+	cell: ReturnType<typeof buildActivityLogWeeks>[number]["cells"][number],
+): boolean {
+	return cell.kind === "data";
+}
+
+function isPlaceholderCell(
+	cell: ReturnType<typeof buildActivityLogWeeks>[number]["cells"][number],
+): boolean {
+	return cell.kind === "placeholder";
+}
+
+function stubMatchMedia(matches: boolean): void {
+	Object.defineProperty(window, "matchMedia", {
+		configurable: true,
+		value: () => ({
+			matches,
+			media: "",
+			onchange: null,
+			addEventListener: () => undefined,
+			removeEventListener: () => undefined,
+			dispatchEvent: () => false,
+		}),
+	});
+}
+
+function stubScrollWidth(value: number): () => void {
+	const descriptor = Object.getOwnPropertyDescriptor(
+		HTMLElement.prototype,
+		"scrollWidth",
+	);
+	Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+		configurable: true,
+		get: () => value,
+	});
+	return () => {
+		if (descriptor) {
+			Object.defineProperty(HTMLElement.prototype, "scrollWidth", descriptor);
+		}
+	};
+}

--- a/web-app/src/features/home/activity-log.tsx
+++ b/web-app/src/features/home/activity-log.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useRef } from "react";
+import type { ActivityLogEntry } from "./home.contract";
+
+const DAYS_PER_WEEK = 7;
+const MOBILE_MEDIA_QUERY = "(max-width: 767px)";
+
+export type ActivityLogLevel =
+	| "null"
+	| "zero"
+	| "level-1"
+	| "level-2"
+	| "level-3"
+	| "level-4";
+
+type DateOnly = {
+	year: number;
+	month: number;
+	day: number;
+	weekday: number;
+};
+
+type ActivityLogDataCell = {
+	kind: "data";
+	entry: ActivityLogEntry;
+	date: DateOnly;
+	level: ActivityLogLevel;
+};
+
+type ActivityLogPlaceholderCell = {
+	kind: "placeholder";
+	id: string;
+};
+
+type ActivityLogCell = ActivityLogDataCell | ActivityLogPlaceholderCell;
+
+export type ActivityLogWeek = {
+	id: string;
+	cells: ActivityLogCell[];
+	monthLabels: string[];
+};
+
+/** RFC 3339 full-date をローカルタイムゾーンに依存せず曜日へ変換する。 */
+export function parseDateOnly(date: string): DateOnly {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+	if (!match) {
+		throw new Error(`Invalid full-date: ${date}`);
+	}
+
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const utcDate = new Date(Date.UTC(year, month - 1, day));
+	if (
+		utcDate.getUTCFullYear() !== year ||
+		utcDate.getUTCMonth() !== month - 1 ||
+		utcDate.getUTCDate() !== day
+	) {
+		throw new Error(`Invalid full-date: ${date}`);
+	}
+
+	return { year, month, day, weekday: utcDate.getUTCDay() };
+}
+
+export function getActivityLogLevel(
+	completionRate: number | null,
+): ActivityLogLevel {
+	if (completionRate === null) {
+		return "null";
+	}
+	if (completionRate === 0) {
+		return "zero";
+	}
+	if (completionRate > 0 && completionRate <= 0.25) {
+		return "level-1";
+	}
+	if (completionRate > 0.25 && completionRate <= 0.5) {
+		return "level-2";
+	}
+	if (completionRate > 0.5 && completionRate < 1) {
+		return "level-3";
+	}
+	if (completionRate === 1) {
+		return "level-4";
+	}
+
+	throw new Error(`Invalid completion rate: ${completionRate}`);
+}
+
+export function getActivityLogAriaLabel(entry: ActivityLogEntry): string {
+	if (entry.completionRate === null) {
+		return `${entry.date}: 未確定または対象なし`;
+	}
+	return `${entry.date}: 達成率 ${Math.round(entry.completionRate * 100)}%`;
+}
+
+/**
+ * oldest → newest の API データを、日曜始まり・週単位の列に変換する。
+ * 先頭と末尾だけを埋める placeholder は実データとして公開しない。
+ */
+export function buildActivityLogWeeks(
+	entries: ActivityLogEntry[],
+): ActivityLogWeek[] {
+	if (entries.length === 0) {
+		return [];
+	}
+
+	const parsedEntries = entries.map((entry) => ({
+		entry,
+		date: parseDateOnly(entry.date),
+	}));
+	const cells: ActivityLogCell[] = [
+		...Array.from(
+			{ length: parsedEntries[0].date.weekday },
+			(_, index): ActivityLogPlaceholderCell => ({
+				kind: "placeholder",
+				id: `leading-${index}`,
+			}),
+		),
+		...parsedEntries.map<ActivityLogDataCell>(({ entry, date }) => ({
+			kind: "data",
+			entry,
+			date,
+			level: getActivityLogLevel(entry.completionRate),
+		})),
+	];
+	const trailingPlaceholders =
+		(DAYS_PER_WEEK - (cells.length % DAYS_PER_WEEK)) % DAYS_PER_WEEK;
+	cells.push(
+		...Array.from(
+			{ length: trailingPlaceholders },
+			(_, index): ActivityLogPlaceholderCell => ({
+				kind: "placeholder",
+				id: `trailing-${index}`,
+			}),
+		),
+	);
+
+	let previousMonth: string | undefined;
+	return Array.from(
+		{ length: cells.length / DAYS_PER_WEEK },
+		(_, weekIndex): ActivityLogWeek => {
+			const weekCells = cells.slice(
+				weekIndex * DAYS_PER_WEEK,
+				(weekIndex + 1) * DAYS_PER_WEEK,
+			);
+			const monthLabels: string[] = [];
+			for (const cell of weekCells) {
+				if (cell.kind !== "data") {
+					continue;
+				}
+				const month = `${cell.date.year}-${cell.date.month}`;
+				if (month !== previousMonth) {
+					monthLabels.push(`${cell.date.month}月`);
+					previousMonth = month;
+				}
+			}
+			return {
+				id: weekCells
+					.map((cell) => (cell.kind === "data" ? cell.entry.date : cell.id))
+					.join("-"),
+				cells: weekCells,
+				monthLabels,
+			};
+		},
+	);
+}
+
+export function ActivityLog({ entries }: { entries: ActivityLogEntry[] }) {
+	const scrollAreaRef = useRef<HTMLDivElement>(null);
+	const hasInitialRightAlignment = useRef(false);
+	const weeks = buildActivityLogWeeks(entries);
+
+	useEffect(() => {
+		if (
+			weeks.length === 0 ||
+			hasInitialRightAlignment.current ||
+			!scrollAreaRef.current ||
+			typeof window.matchMedia !== "function" ||
+			!window.matchMedia(MOBILE_MEDIA_QUERY).matches
+		) {
+			return;
+		}
+
+		scrollAreaRef.current.scrollLeft = scrollAreaRef.current.scrollWidth;
+		hasInitialRightAlignment.current = true;
+	}, [weeks.length]);
+
+	return (
+		<section aria-label="Activity Log" className="w-full">
+			<div className="mb-2 flex items-center gap-2 text-xs text-stone-600">
+				<span>少ない</span>
+				<ActivityLogLegend />
+				<span>多い</span>
+			</div>
+			<div className="flex gap-2">
+				<div
+					aria-hidden="true"
+					className="mt-5 grid h-[4.625rem] grid-rows-7 gap-[3px] text-[0.625rem] leading-[0.625rem] text-stone-500"
+				>
+					<span className="row-start-2">月</span>
+					<span className="row-start-4">水</span>
+					<span className="row-start-6">金</span>
+				</div>
+				<div
+					data-testid="activity-log-scroll-area"
+					ref={scrollAreaRef}
+					className="min-w-0 flex-1 overflow-x-auto pb-1"
+				>
+					<div className="min-w-[38rem]">
+						<div
+							aria-hidden="true"
+							className="mb-1 grid h-3 gap-[3px] text-[0.625rem] leading-3 text-stone-500"
+							style={{
+								gridTemplateColumns: `repeat(${weeks.length}, 0.625rem)`,
+							}}
+						>
+							{weeks.map((week) => (
+								<div key={`month-${week.id}`} className="whitespace-nowrap">
+									{week.monthLabels.map((label) => (
+										<span key={label} data-testid="activity-log-month-label">
+											{label}
+										</span>
+									))}
+								</div>
+							))}
+						</div>
+						{/* biome-ignore lint/a11y/useSemanticElements: 日付を週列で並べる非操作グラフにはWAI-ARIA gridを使う。 */}
+						<div
+							aria-colcount={weeks.length}
+							aria-label="直近365日の達成率"
+							aria-rowcount={DAYS_PER_WEEK}
+							className="grid gap-[3px]"
+							role="grid"
+							style={{
+								gridTemplateColumns: `repeat(${weeks.length}, 0.625rem)`,
+							}}
+						>
+							{weeks.map((week) => (
+								<div className="grid grid-rows-7 gap-[3px]" key={week.id}>
+									{week.cells.map((cell) =>
+										cell.kind === "placeholder" ? (
+											<div
+												aria-hidden="true"
+												className="size-2.5"
+												data-activity-placeholder="true"
+												key={`${week.id}-${cell.id}`}
+											/>
+										) : (
+											/* biome-ignore lint/a11y/useFocusableInteractive lint/a11y/useSemanticElements: セルは仕様上、情報提示専用でTab stopにしない。 */
+											<div
+												aria-label={getActivityLogAriaLabel(cell.entry)}
+												className="size-2.5 rounded-[2px] outline outline-1 outline-transparent"
+												data-activity-level={cell.level}
+												key={cell.entry.date}
+												role="gridcell"
+												title={getActivityLogAriaLabel(cell.entry)}
+											/>
+										),
+									)}
+								</div>
+							))}
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+function ActivityLogLegend() {
+	return (
+		<span aria-hidden="true" className="flex gap-[3px]">
+			{(
+				["null", "zero", "level-1", "level-2", "level-3", "level-4"] as const
+			).map((level) => (
+				<span
+					className="size-2.5 rounded-[2px] outline outline-1 outline-transparent"
+					data-activity-level={level}
+					key={level}
+				/>
+			))}
+		</span>
+	);
+}

--- a/web-app/src/features/home/activity-log.tsx
+++ b/web-app/src/features/home/activity-log.tsx
@@ -3,6 +3,15 @@ import type { ActivityLogEntry } from "./home.contract";
 
 const DAYS_PER_WEEK = 7;
 const MOBILE_MEDIA_QUERY = "(max-width: 767px)";
+const WEEKDAY_ROW_IDS = [
+	"sunday",
+	"monday",
+	"tuesday",
+	"wednesday",
+	"thursday",
+	"friday",
+	"saturday",
+] as const;
 
 export type ActivityLogLevel =
 	| "null"
@@ -195,7 +204,8 @@ export function ActivityLog({ entries }: { entries: ActivityLogEntry[] }) {
 			<div className="flex gap-2">
 				<div
 					aria-hidden="true"
-					className="mt-5 grid h-[4.625rem] grid-rows-7 gap-[3px] text-[0.625rem] leading-[0.625rem] text-stone-500"
+					className="mt-[13px] grid h-[5.5rem] grid-rows-[repeat(7,0.625rem)] gap-[3px] text-[0.625rem] leading-[0.625rem] text-stone-500"
+					data-testid="activity-log-weekday-labels"
 				>
 					<span className="row-start-2">月</span>
 					<span className="row-start-4">水</span>
@@ -209,7 +219,7 @@ export function ActivityLog({ entries }: { entries: ActivityLogEntry[] }) {
 					<div className="min-w-[38rem]">
 						<div
 							aria-hidden="true"
-							className="mb-1 grid h-3 gap-[3px] text-[0.625rem] leading-3 text-stone-500"
+							className="mb-[3px] grid h-2.5 gap-[3px] text-[0.625rem] leading-2.5 text-stone-500"
 							style={{
 								gridTemplateColumns: `repeat(${weeks.length}, 0.625rem)`,
 							}}
@@ -229,34 +239,50 @@ export function ActivityLog({ entries }: { entries: ActivityLogEntry[] }) {
 							aria-colcount={weeks.length}
 							aria-label="直近365日の達成率"
 							aria-rowcount={DAYS_PER_WEEK}
-							className="grid gap-[3px]"
+							className="grid grid-rows-[repeat(7,0.625rem)] gap-[3px]"
+							data-testid="activity-log-grid"
 							role="grid"
-							style={{
-								gridTemplateColumns: `repeat(${weeks.length}, 0.625rem)`,
-							}}
 						>
-							{weeks.map((week) => (
-								<div className="grid grid-rows-7 gap-[3px]" key={week.id}>
-									{week.cells.map((cell) =>
-										cell.kind === "placeholder" ? (
+							{WEEKDAY_ROW_IDS.map((rowId, rowIndex) => (
+								/* biome-ignore lint/a11y/useSemanticElements lint/a11y/useFocusableInteractive: 非操作の可視化グリッドで、行自体をTab stopにしない。 */
+								<div
+									aria-rowindex={rowIndex + 1}
+									className="grid h-2.5 gap-[3px]"
+									data-activity-week-row={rowIndex + 1}
+									key={rowId}
+									role="row"
+									style={{
+										gridTemplateColumns: `repeat(${weeks.length}, 0.625rem)`,
+									}}
+								>
+									{weeks.map((week, columnIndex) => {
+										const cell = week.cells[rowIndex];
+										if (!cell) {
+											return null;
+										}
+
+										return cell.kind === "placeholder" ? (
 											<div
 												aria-hidden="true"
 												className="size-2.5"
 												data-activity-placeholder="true"
 												key={`${week.id}-${cell.id}`}
+												role="presentation"
 											/>
 										) : (
 											/* biome-ignore lint/a11y/useFocusableInteractive lint/a11y/useSemanticElements: セルは仕様上、情報提示専用でTab stopにしない。 */
 											<div
 												aria-label={getActivityLogAriaLabel(cell.entry)}
-												className="size-2.5 rounded-[2px] outline outline-1 outline-transparent"
+												aria-colindex={columnIndex + 1}
+												aria-rowindex={rowIndex + 1}
+												className="size-2.5 rounded-[2px] outline outline-1"
 												data-activity-level={cell.level}
 												key={cell.entry.date}
 												role="gridcell"
 												title={getActivityLogAriaLabel(cell.entry)}
 											/>
-										),
-									)}
+										);
+									})}
 								</div>
 							))}
 						</div>
@@ -274,7 +300,7 @@ function ActivityLogLegend() {
 				["null", "zero", "level-1", "level-2", "level-3", "level-4"] as const
 			).map((level) => (
 				<span
-					className="size-2.5 rounded-[2px] outline outline-1 outline-transparent"
+					className="size-2.5 rounded-[2px] outline outline-1"
 					data-activity-level={level}
 					key={level}
 				/>


### PR DESCRIPTION
## 概要

`GET /api/home` の `activityLog` を描画する、API・認証・Query非依存のActivity Logコンポーネントを実装しました。

Closes #37

## 変更内容

- 365件の実データを日曜始まり・週列のcontribution-style gridへ変換
- full-dateをUTC componentで検証・解釈し、browser timezoneによる曜日ずれを防止
- leading/trailing placeholderを実データ・ARIA・tooltipから分離
- `null`、`zero`、緑4段階の境界とlight-only色を実装
- 月・曜日・日本語凡例、365個の非interactive `gridcell` とaccessible labelを追加
- mobileは実データ初回表示時だけ最新側へ寄せ、rerender時のscroll位置を維持
- desktopではscroll位置を強制せず、コンパクトな固定cellで表示

## 確認

- `pnpm test`（16 files / 123 tests）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`

ローカルNode 20ではNode 26 engine warningが出ますが、GitHub CIはrepository指定のNode 26を使用します。
