### PR TITLE
今日の習慣一覧と達成UIを実装

### DIFF
--- a/web-app/src/features/habits/complete-button.tsx
+++ b/web-app/src/features/habits/complete-button.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from "react";
+import type { HomeHabit } from "~/features/home/home.contract";
+import { ApiClientError } from "~/lib/api/client";
+import {
+	useCompleteHabitMutation,
+	useIsHabitMutationPending,
+} from "./habits.mutations";
+
+type CompleteButtonProps = {
+	habit: HomeHabit;
+	onUnauthorized?: () => void | Promise<void>;
+};
+
+export function getCompleteHabitErrorMessage(error: unknown): string | null {
+	if (error == null) {
+		return null;
+	}
+	if (!(error instanceof ApiClientError)) {
+		return "通信に失敗しました。接続を確認して再試行してください";
+	}
+	if (error.status === 401) {
+		return null;
+	}
+	switch (error.code) {
+		case "HABIT_ALREADY_COMPLETED_TODAY":
+			return "この習慣は本日すでに達成済みです";
+		case "HABIT_ARCHIVED":
+			return "この習慣はすでにアーカイブされています";
+		case "HABIT_NOT_FOUND":
+			return "習慣が見つかりません";
+		case "INTERNAL_SERVER_ERROR":
+			return "処理に失敗しました。時間をおいて再試行してください";
+		default:
+			return error.status === null
+				? "通信に失敗しました。接続を確認して再試行してください"
+				: "処理に失敗しました。時間をおいて再試行してください";
+	}
+}
+
+export function CompleteButton({ habit, onUnauthorized }: CompleteButtonProps) {
+	const mutation = useCompleteHabitMutation(habit.id, { onUnauthorized });
+	const isHabitMutationPending = useIsHabitMutationPending(habit.id);
+	const submitInFlight = useRef(false);
+	const errorMessage = getCompleteHabitErrorMessage(mutation.error);
+	const { isStaleStateSynchronized, resetStaleStateError } = mutation;
+
+	useEffect(() => {
+		if (isStaleStateSynchronized) {
+			resetStaleStateError();
+		}
+	}, [isStaleStateSynchronized, resetStaleStateError]);
+
+	const handleClick = () => {
+		if (
+			habit.isCompletedToday ||
+			isHabitMutationPending ||
+			submitInFlight.current
+		) {
+			return;
+		}
+
+		submitInFlight.current = true;
+		mutation.mutate(undefined, {
+			onSettled: () => {
+				submitInFlight.current = false;
+			},
+		});
+	};
+
+	const isCompleting = mutation.isPending;
+	const isDisabled = habit.isCompletedToday || isHabitMutationPending;
+	const label = habit.isCompletedToday
+		? "✓ 達成済み"
+		: isCompleting
+			? "達成しています…"
+			: "達成する";
+
+	return (
+		<div className="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:items-end">
+			<button
+				aria-busy={isCompleting || undefined}
+				aria-label={`${habit.name}を${
+					isCompleting
+						? "達成しています"
+						: habit.isCompletedToday
+							? "達成済み"
+							: "達成する"
+				}`}
+				className="inline-flex w-full cursor-pointer items-center justify-center rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-100 disabled:text-emerald-900 sm:w-auto"
+				disabled={isDisabled}
+				onClick={handleClick}
+				type="button"
+			>
+				{label}
+			</button>
+			{errorMessage ? (
+				<p className="text-sm text-red-700" role="alert">
+					{errorMessage}
+				</p>
+			) : null}
+		</div>
+	);
+}

--- a/web-app/src/features/habits/complete-button.tsx
+++ b/web-app/src/features/habits/complete-button.tsx
@@ -42,7 +42,11 @@ export function CompleteButton({ habit, onUnauthorized }: CompleteButtonProps) {
 	const isHabitMutationPending = useIsHabitMutationPending(habit.id);
 	const submitInFlight = useRef(false);
 	const errorMessage = getCompleteHabitErrorMessage(mutation.error);
-	const { isStaleStateSynchronized, resetStaleStateError } = mutation;
+	const {
+		isStaleStateSynchronized,
+		isStaleStateSynchronizing,
+		resetStaleStateError,
+	} = mutation;
 
 	useEffect(() => {
 		if (isStaleStateSynchronized) {
@@ -54,6 +58,7 @@ export function CompleteButton({ habit, onUnauthorized }: CompleteButtonProps) {
 		if (
 			habit.isCompletedToday ||
 			isHabitMutationPending ||
+			isStaleStateSynchronizing ||
 			submitInFlight.current
 		) {
 			return;
@@ -68,23 +73,30 @@ export function CompleteButton({ habit, onUnauthorized }: CompleteButtonProps) {
 	};
 
 	const isCompleting = mutation.isPending;
-	const isDisabled = habit.isCompletedToday || isHabitMutationPending;
+	const isDisabled =
+		habit.isCompletedToday ||
+		isHabitMutationPending ||
+		isStaleStateSynchronizing;
 	const label = habit.isCompletedToday
 		? "✓ 達成済み"
 		: isCompleting
 			? "達成しています…"
-			: "達成する";
+			: isStaleStateSynchronizing
+				? "状態を確認しています…"
+				: "達成する";
 
 	return (
 		<div className="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:items-end">
 			<button
-				aria-busy={isCompleting || undefined}
+				aria-busy={isCompleting || isStaleStateSynchronizing || undefined}
 				aria-label={`${habit.name}を${
 					isCompleting
 						? "達成しています"
-						: habit.isCompletedToday
-							? "達成済み"
-							: "達成する"
+						: isStaleStateSynchronizing
+							? "最新状態を確認しています"
+							: habit.isCompletedToday
+								? "達成済み"
+								: "達成する"
 				}`}
 				className="inline-flex w-full cursor-pointer items-center justify-center rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-100 disabled:text-emerald-900 sm:w-auto"
 				disabled={isDisabled}

--- a/web-app/src/features/habits/habit-card.tsx
+++ b/web-app/src/features/habits/habit-card.tsx
@@ -1,0 +1,35 @@
+import type { HomeHabit } from "~/features/home/home.contract";
+import { CompleteButton } from "./complete-button";
+
+type HabitCardProps = {
+	habit: HomeHabit;
+	onUnauthorized?: () => void | Promise<void>;
+};
+
+export function HabitCard({ habit, onUnauthorized }: HabitCardProps) {
+	return (
+		<article
+			className={`rounded-xl border p-4 shadow-sm ${
+				habit.isCompletedToday
+					? "border-emerald-200 bg-emerald-50"
+					: "border-stone-200 bg-white"
+			}`}
+			data-completed={habit.isCompletedToday ? "true" : "false"}
+		>
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+				<div className="min-w-0">
+					<h3 className="flex items-center gap-2 text-base font-semibold text-stone-950">
+						{habit.emoji === "" ? null : (
+							<span aria-hidden="true">{habit.emoji}</span>
+						)}
+						<span>{habit.name}</span>
+					</h3>
+					<p className="mt-1 text-sm text-stone-600">
+						現在 {habit.currentStreak}日 ・ 最長 {habit.maxStreak}日
+					</p>
+				</div>
+				<CompleteButton habit={habit} onUnauthorized={onUnauthorized} />
+			</div>
+		</article>
+	);
+}

--- a/web-app/src/features/habits/habit-list.test.tsx
+++ b/web-app/src/features/habits/habit-list.test.tsx
@@ -1,0 +1,390 @@
+import {
+	QueryClient,
+	QueryClientProvider,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+	HomeDataResponse,
+	HomeHabit,
+} from "~/features/home/home.contract";
+import { homeQueryKey, homeQueryOptions } from "~/features/home/home.query";
+import { HabitList } from "./habit-list";
+import { habitMutationKey } from "./habits.mutations";
+import { TodaySummary } from "./today-summary";
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("TodaySummary と HabitList", () => {
+	it("API返却順、絵文字、ストリーク、達成状態を仕様どおり表示する", () => {
+		const habits = [
+			makeHabit({
+				id: "second",
+				name: "後の習慣",
+				emoji: "",
+				currentStreak: 0,
+				maxStreak: 2,
+			}),
+			makeHabit({
+				id: "first",
+				name: "先の習慣",
+				emoji: "📚",
+				currentStreak: 3,
+				maxStreak: 14,
+				isCompletedToday: true,
+			}),
+		];
+		renderWithClient(
+			<>
+				<TodaySummary habits={habits} />
+				<HabitList habits={habits} />
+			</>,
+		);
+
+		expect(screen.getByTestId("today-summary")).toHaveTextContent("1 / 2 完了");
+		expect(
+			screen
+				.getAllByRole("heading", { level: 3 })
+				.map((heading) => heading.textContent),
+		).toEqual(["後の習慣", "📚先の習慣"]);
+		expect(screen.getByText("現在 0日 ・ 最長 2日")).toBeInTheDocument();
+		expect(screen.getByText("現在 3日 ・ 最長 14日")).toBeInTheDocument();
+		expect(screen.queryByText("⬜")).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "先の習慣を達成済み" }),
+		).toBeDisabled();
+		expect(
+			screen.getByRole("button", { name: "後の習慣を達成する" }),
+		).toHaveClass("w-full", "sm:w-auto");
+		expect(document.querySelector('[data-completed="true"]')).toHaveClass(
+			"bg-emerald-50",
+			"border-emerald-200",
+		);
+		expect(
+			screen.queryByRole("button", { name: /操作メニュー/ }),
+		).not.toBeInTheDocument();
+	});
+
+	it("対象習慣がない場合は空状態だけを表示し、0 / 0 完了を表示しない", () => {
+		renderWithClient(
+			<>
+				<TodaySummary habits={[]} />
+				<HabitList habits={[]} />
+			</>,
+		);
+
+		expect(
+			screen.getByText("今日の習慣はまだありません。"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("まずは小さな習慣を1つ追加しましょう。"),
+		).toBeInTheDocument();
+		expect(screen.queryByTestId("today-summary")).not.toBeInTheDocument();
+		expect(screen.queryByRole("button")).not.toBeInTheDocument();
+	});
+
+	it("達成済み習慣はAPIを呼ばず、同一習慣の別mutation中もcompleteを開始しない", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal("fetch", fetchMock);
+		const queryClient = createQueryClient();
+		const completed = render(
+			<HabitList habits={[makeHabit({ isCompletedToday: true })]} />,
+			{ wrapper: wrapper(queryClient) },
+		);
+		await user.click(screen.getByRole("button", { name: "読書を達成済み" }));
+		expect(fetchMock).not.toHaveBeenCalled();
+		completed.unmount();
+
+		const pending = deferred<void>();
+		const updateMutation = queryClient.getMutationCache().build(queryClient, {
+			mutationKey: habitMutationKey("reading", "update"),
+			mutationFn: () => pending.promise,
+		});
+		const updateExecution = updateMutation.execute(undefined);
+		render(<HabitList habits={[makeHabit()]} />, {
+			wrapper: wrapper(queryClient),
+		});
+		await vi.waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: "読書を達成する" }),
+			).toBeDisabled(),
+		);
+		await user.click(screen.getByRole("button", { name: "読書を達成する" }));
+		expect(fetchMock).not.toHaveBeenCalled();
+		pending.resolve();
+		await updateExecution;
+	});
+
+	it("対象の習慣だけをpendingにして二重送信を防ぎ、成功時にsummaryとcardを更新する", async () => {
+		const user = userEvent.setup();
+		const initialHome = makeHomeData();
+		const complete = deferred<Response>();
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					return Promise.resolve(jsonResponse(initialHome));
+				}
+				return complete.promise;
+			}),
+		);
+		const queryClient = createQueryClient();
+		render(<HomeHabitList />, { wrapper: wrapper(queryClient) });
+		await screen.findByText("1 / 3 完了");
+
+		const readingButton = screen.getByRole("button", {
+			name: "読書を達成する",
+		});
+		const exerciseButton = screen.getByRole("button", {
+			name: "運動を達成する",
+		});
+		const activityLogBeforeComplete =
+			queryClient.getQueryData<HomeDataResponse>(homeQueryKey)?.activityLog;
+		await user.dblClick(readingButton);
+
+		expect(
+			fetchMock.mock.calls.filter(
+				([path]) => path === "/api/habits/reading/complete",
+			),
+		).toHaveLength(1);
+		expect(
+			screen.getByRole("button", { name: "読書を達成しています" }),
+		).toHaveTextContent("達成しています…");
+		expect(
+			screen.getByRole("button", { name: "読書を達成しています" }),
+		).toHaveAttribute("aria-busy", "true");
+		expect(exerciseButton).not.toBeDisabled();
+
+		await act(async () => {
+			complete.resolve(jsonResponse(completeResponse("reading")));
+		});
+		await screen.findByText("2 / 3 完了");
+		expect(screen.getByTestId("today-summary")).toHaveAttribute(
+			"aria-live",
+			"polite",
+		);
+		expect(
+			screen.getByRole("button", { name: "読書を達成済み" }),
+		).toBeDisabled();
+		expect(
+			queryClient.getQueryData<HomeDataResponse>(homeQueryKey)?.activityLog,
+		).toBe(activityLogBeforeComplete);
+	});
+
+	it.each([
+		["HABIT_ALREADY_COMPLETED_TODAY", 409, "この習慣は本日すでに達成済みです"],
+		["HABIT_ARCHIVED", 409, "この習慣はすでにアーカイブされています"],
+		["HABIT_NOT_FOUND", 404, "習慣が見つかりません"],
+		[
+			"INTERNAL_SERVER_ERROR",
+			500,
+			"処理に失敗しました。時間をおいて再試行してください",
+		],
+	] as const)(
+		"%s をカード付近のrole=alertで表示する",
+		async (code, status, message) => {
+			const user = userEvent.setup();
+			vi.stubGlobal(
+				"fetch",
+				fetchMock.mockResolvedValue(
+					jsonResponse({ code, message: "APIの任意文言" }, status),
+				),
+			);
+			renderWithClient(<HabitList habits={[makeHabit()]} />);
+
+			await user.click(screen.getByRole("button", { name: "読書を達成する" }));
+			expect(await screen.findByRole("alert")).toHaveTextContent(message);
+		},
+	);
+
+	it("network errorをカード付近のrole=alertで表示する", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal("fetch", fetchMock.mockRejectedValue(new Error("offline")));
+		renderWithClient(<HabitList habits={[makeHabit()]} />);
+
+		await user.click(screen.getByRole("button", { name: "読書を達成する" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"通信に失敗しました。接続を確認して再試行してください",
+		);
+	});
+
+	it("401はカードエラーを出さずglobal auth callbackへ委譲する", async () => {
+		const user = userEvent.setup();
+		const onUnauthorized = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValue(
+				jsonResponse(
+					{ code: "UNAUTHORIZED", message: "ログインが必要です。" },
+					401,
+				),
+			),
+		);
+		renderWithClient(
+			<HabitList habits={[makeHabit()]} onUnauthorized={onUnauthorized} />,
+		);
+
+		await user.click(screen.getByRole("button", { name: "読書を達成する" }));
+		await vi.waitFor(() => expect(onUnauthorized).toHaveBeenCalledTimes(1));
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("stale-state errorは成功したhome再同期後にだけ消去する", async () => {
+		const user = userEvent.setup();
+		const initialHome = makeHomeData();
+		const synchronization = deferred<Response>();
+		let homeRequestCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					return homeRequestCount === 1
+						? Promise.resolve(jsonResponse(initialHome))
+						: synchronization.promise;
+				}
+				return Promise.resolve(
+					jsonResponse(
+						{
+							code: "HABIT_ALREADY_COMPLETED_TODAY",
+							message: "達成済みです。",
+						},
+						409,
+					),
+				);
+			}),
+		);
+		const queryClient = createQueryClient();
+		render(<HomeHabitList />, { wrapper: wrapper(queryClient) });
+		await screen.findByText("1 / 3 完了");
+
+		await user.click(screen.getByRole("button", { name: "読書を達成する" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"この習慣は本日すでに達成済みです",
+		);
+		await vi.waitFor(() => expect(homeRequestCount).toBe(2));
+		synchronization.resolve(
+			jsonResponse({
+				...initialHome,
+				habits: [
+					{ ...initialHome.habits[0], isCompletedToday: true },
+					initialHome.habits[1],
+				],
+			}),
+		);
+
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+		);
+		expect(
+			screen.getByRole("button", { name: "読書を達成済み" }),
+		).toBeDisabled();
+	});
+});
+
+function HomeHabitList() {
+	const queryClient = useQueryClient();
+	const home = useQuery(homeQueryOptions({ enabled: true }, queryClient));
+	if (!home.data) {
+		return <p>読み込み中…</p>;
+	}
+	return (
+		<>
+			<TodaySummary habits={home.data.habits} />
+			<HabitList habits={home.data.habits} />
+		</>
+	);
+}
+
+function renderWithClient(ui: React.ReactElement) {
+	return render(ui, { wrapper: wrapper(createQueryClient()) });
+}
+
+function wrapper(queryClient: QueryClient) {
+	return function QueryWrapper({ children }: PropsWithChildren) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+function createQueryClient(): QueryClient {
+	return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function makeHabit(overrides: Partial<HomeHabit> = {}): HomeHabit {
+	return {
+		id: "reading",
+		name: "読書",
+		emoji: "📚",
+		currentStreak: 3,
+		maxStreak: 14,
+		isCompletedToday: false,
+		...overrides,
+	};
+}
+
+function makeHomeData(): HomeDataResponse {
+	return {
+		habits: [
+			makeHabit({ isCompletedToday: false }),
+			makeHabit({
+				id: "exercise",
+				name: "運動",
+				emoji: "🏃",
+				isCompletedToday: false,
+			}),
+			makeHabit({
+				id: "walk",
+				name: "散歩",
+				emoji: "🚶",
+				isCompletedToday: true,
+			}),
+		],
+		activityLog: [{ date: "2026-08-08", completionRate: null }],
+	};
+}
+
+function completeResponse(id: string) {
+	return {
+		dailyRecord: {
+			id: "record-1",
+			habitId: id,
+			date: "2026-08-08",
+			completedAt: "2026-08-08T12:00:00+09:00",
+		},
+		habit: {
+			id,
+			name: "読書",
+			emoji: "📚",
+			currentStreak: 4,
+			maxStreak: 14,
+			isCompletedToday: true,
+		},
+	};
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}

--- a/web-app/src/features/habits/habit-list.test.tsx
+++ b/web-app/src/features/habits/habit-list.test.tsx
@@ -273,6 +273,17 @@ describe("TodaySummary と HabitList", () => {
 			"この習慣は本日すでに達成済みです",
 		);
 		await vi.waitFor(() => expect(homeRequestCount).toBe(2));
+		const synchronizingButton = screen.getByRole("button", {
+			name: "読書を最新状態を確認しています",
+		});
+		expect(synchronizingButton).toBeDisabled();
+		expect(synchronizingButton).toHaveAttribute("aria-busy", "true");
+		await user.click(synchronizingButton);
+		expect(
+			fetchMock.mock.calls.filter(
+				([path]) => path === "/api/habits/reading/complete",
+			),
+		).toHaveLength(1);
 		synchronization.resolve(
 			jsonResponse({
 				...initialHome,
@@ -289,6 +300,68 @@ describe("TodaySummary と HabitList", () => {
 		expect(
 			screen.getByRole("button", { name: "読書を達成済み" }),
 		).toBeDisabled();
+	});
+
+	it("stale-state 再同期GETが失敗するとalertを維持し、再試行を許可する", async () => {
+		const user = userEvent.setup();
+		const initialHome = makeHomeData();
+		const synchronization = deferred<Response>();
+		let homeRequestCount = 0;
+		let completeRequestCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					return homeRequestCount === 1
+						? Promise.resolve(jsonResponse(initialHome))
+						: synchronization.promise;
+				}
+				completeRequestCount += 1;
+				return Promise.resolve(
+					completeRequestCount === 1
+						? jsonResponse(
+								{
+									code: "HABIT_ALREADY_COMPLETED_TODAY",
+									message: "達成済みです。",
+								},
+								409,
+							)
+						: jsonResponse(completeResponse("reading")),
+				);
+			}),
+		);
+		const queryClient = createQueryClient();
+		render(<HomeHabitList />, { wrapper: wrapper(queryClient) });
+		await screen.findByText("1 / 3 完了");
+
+		await user.click(screen.getByRole("button", { name: "読書を達成する" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"この習慣は本日すでに達成済みです",
+		);
+		await vi.waitFor(() => expect(homeRequestCount).toBe(2));
+		expect(
+			screen.getByRole("button", {
+				name: "読書を最新状態を確認しています",
+			}),
+		).toBeDisabled();
+
+		synchronization.resolve(jsonResponse({ message: "failed" }, 400));
+		const retryButton = await screen.findByRole("button", {
+			name: "読書を達成する",
+		});
+		expect(retryButton).toBeEnabled();
+		expect(retryButton).not.toHaveAttribute("aria-busy");
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"この習慣は本日すでに達成済みです",
+		);
+
+		await user.click(retryButton);
+		expect(
+			fetchMock.mock.calls.filter(
+				([path]) => path === "/api/habits/reading/complete",
+			),
+		).toHaveLength(2);
 	});
 });
 

--- a/web-app/src/features/habits/habit-list.tsx
+++ b/web-app/src/features/habits/habit-list.tsx
@@ -1,0 +1,28 @@
+import type { HomeHabit } from "~/features/home/home.contract";
+import { HabitCard } from "./habit-card";
+
+type HabitListProps = {
+	habits: readonly HomeHabit[];
+	onUnauthorized?: () => void | Promise<void>;
+};
+
+export function HabitList({ habits, onUnauthorized }: HabitListProps) {
+	if (habits.length === 0) {
+		return (
+			<div className="rounded-xl border border-dashed border-stone-300 bg-stone-50 p-6 text-sm text-stone-600">
+				<p>今日の習慣はまだありません。</p>
+				<p className="mt-1">まずは小さな習慣を1つ追加しましょう。</p>
+			</div>
+		);
+	}
+
+	return (
+		<ul className="space-y-3" aria-label="今日の習慣一覧">
+			{habits.map((habit) => (
+				<li key={habit.id}>
+					<HabitCard habit={habit} onUnauthorized={onUnauthorized} />
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/web-app/src/features/habits/habits.mutations.test.tsx
+++ b/web-app/src/features/habits/habits.mutations.test.tsx
@@ -289,6 +289,67 @@ describe("habit mutations", () => {
 		await waitFor(() => expect(result.current.error).toBeNull());
 	});
 
+	it("新しいcomplete開始後は先行するstale同期の完了を引き継がない", async () => {
+		const queryClient = createQueryClient();
+		let completeRequestCount = 0;
+		let homeRequestCount = 0;
+		let resolveFirstSynchronization: ((response: Response) => void) | undefined;
+		let resolveSecondComplete: ((response: Response) => void) | undefined;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					if (homeRequestCount === 1) {
+						return Promise.resolve(jsonResponse(homeData));
+					}
+					return new Promise<Response>((resolve) => {
+						resolveFirstSynchronization ??= resolve;
+					});
+				}
+				completeRequestCount += 1;
+				if (completeRequestCount === 1) {
+					return Promise.resolve(
+						jsonResponse(
+							{
+								code: "HABIT_ALREADY_COMPLETED_TODAY",
+								message: "達成済みです。",
+							},
+							409,
+						),
+					);
+				}
+				return new Promise<Response>((resolve) => {
+					resolveSecondComplete = resolve;
+				});
+			}),
+		);
+		renderHook(() => useHomeQuery({ enabled: true, userId: "user-a" }), {
+			wrapper: wrapper(queryClient),
+		});
+		const { result } = renderHook(() => useCompleteHabitMutation("habit-1"), {
+			wrapper: wrapper(queryClient),
+		});
+		await waitFor(() => expect(homeRequestCount).toBe(1));
+
+		await expect(result.current.mutateAsync()).rejects.toMatchObject({
+			code: "HABIT_ALREADY_COMPLETED_TODAY",
+		});
+		await waitFor(() =>
+			expect(resolveFirstSynchronization).toBeTypeOf("function"),
+		);
+		act(() => {
+			result.current.mutate();
+		});
+		await waitFor(() => expect(resolveSecondComplete).toBeTypeOf("function"));
+		resolveFirstSynchronization?.(jsonResponse(homeData));
+
+		await waitFor(() => expect(result.current.isPending).toBe(true));
+		expect(result.current.isStaleStateSynchronized).toBe(false);
+		resolveSecondComplete?.(jsonResponse(completeResponse));
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
 	it("stale-state error後のGET失敗時はerrorをreset可能にしない", async () => {
 		const queryClient = createQueryClient();
 		let homeRequestCount = 0;

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -4,7 +4,7 @@ import {
 	useMutation,
 	useQueryClient,
 } from "@tanstack/react-query";
-import { type RefObject, useCallback, useRef } from "react";
+import { type RefObject, useCallback, useRef, useState } from "react";
 import type { HomeDataResponse } from "~/features/home/home.contract";
 import {
 	clearHomeCache,
@@ -63,16 +63,56 @@ function isStaleStateError(error: unknown): boolean {
 function useStaleStateErrorReset(
 	error: unknown,
 	reset: () => void,
-	synchronized: RefObject<boolean>,
+	synchronizedRef: RefObject<boolean>,
+	clearSynchronized: () => void,
 ) {
 	return useCallback(() => {
-		if (!synchronized.current || !isStaleStateError(error)) {
+		if (!synchronizedRef.current || !isStaleStateError(error)) {
 			return false;
 		}
 		reset();
-		synchronized.current = false;
+		clearSynchronized();
 		return true;
-	}, [error, reset, synchronized]);
+	}, [clearSynchronized, error, reset, synchronizedRef]);
+}
+
+/**
+ * stale-state error の再同期完了を render に通知する。ref だけでは非同期 GET
+ * 完了後に HabitCard が再描画されず、表示済みのエラーを消去できないため state も
+ * 併用する。直近の mutation error だけが状態を更新する。
+ */
+function useStaleStateSynchronization() {
+	const [isSynchronized, setIsSynchronized] = useState(false);
+	const synchronizedRef = useRef(false);
+	const sequenceRef = useRef(0);
+	const beginSynchronization = useCallback(() => {
+		sequenceRef.current += 1;
+		synchronizedRef.current = false;
+		setIsSynchronized(false);
+		return sequenceRef.current;
+	}, []);
+	const completeSynchronization = useCallback(
+		(sequence: number, synchronized: boolean) => {
+			if (sequence === sequenceRef.current) {
+				synchronizedRef.current = synchronized;
+				setIsSynchronized(synchronized);
+			}
+		},
+		[],
+	);
+	const clearSynchronization = useCallback(() => {
+		sequenceRef.current += 1;
+		synchronizedRef.current = false;
+		setIsSynchronized(false);
+	}, []);
+
+	return {
+		isSynchronized,
+		synchronizedRef,
+		beginSynchronization,
+		completeSynchronization,
+		clearSynchronization,
+	};
 }
 
 async function synchronizeMutationError(
@@ -155,29 +195,40 @@ export function useUpdateHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
 	const queryClient = useQueryClient();
-	const staleStateSynchronized = useRef(false);
+	const staleStateSynchronization = useStaleStateSynchronization();
 	const mutation = useMutation({
 		mutationKey: habitMutationKey(habitId, "update"),
 		mutationFn: (request: UpdateHabitRequest) =>
 			updateHabitRequest(habitId, request),
+		onMutate: () => {
+			staleStateSynchronization.clearSynchronization();
+		},
 		onSuccess: () => invalidateAndRefetchHome(queryClient),
 		onError: (error) => {
-			staleStateSynchronized.current = false;
+			const sequence = staleStateSynchronization.beginSynchronization();
 			void synchronizeMutationError(
 				queryClient,
 				error,
 				options.onUnauthorized,
 			).then((synchronized) => {
-				staleStateSynchronized.current = synchronized;
+				staleStateSynchronization.completeSynchronization(
+					sequence,
+					synchronized,
+				);
 			});
 		},
 	});
 	const resetStaleStateError = useStaleStateErrorReset(
 		mutation.error,
 		mutation.reset,
-		staleStateSynchronized,
+		staleStateSynchronization.synchronizedRef,
+		staleStateSynchronization.clearSynchronization,
 	);
-	return { ...mutation, resetStaleStateError };
+	return {
+		...mutation,
+		resetStaleStateError,
+		isStaleStateSynchronized: staleStateSynchronization.isSynchronized,
+	};
 }
 
 export function useArchiveHabitMutation(
@@ -185,28 +236,39 @@ export function useArchiveHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
 	const queryClient = useQueryClient();
-	const staleStateSynchronized = useRef(false);
+	const staleStateSynchronization = useStaleStateSynchronization();
 	const mutation = useMutation({
 		mutationKey: habitMutationKey(habitId, "archive"),
 		mutationFn: () => archiveHabitRequest(habitId),
+		onMutate: () => {
+			staleStateSynchronization.clearSynchronization();
+		},
 		onSuccess: () => invalidateAndRefetchHome(queryClient),
 		onError: (error) => {
-			staleStateSynchronized.current = false;
+			const sequence = staleStateSynchronization.beginSynchronization();
 			void synchronizeMutationError(
 				queryClient,
 				error,
 				options.onUnauthorized,
 			).then((synchronized) => {
-				staleStateSynchronized.current = synchronized;
+				staleStateSynchronization.completeSynchronization(
+					sequence,
+					synchronized,
+				);
 			});
 		},
 	});
 	const resetStaleStateError = useStaleStateErrorReset(
 		mutation.error,
 		mutation.reset,
-		staleStateSynchronized,
+		staleStateSynchronization.synchronizedRef,
+		staleStateSynchronization.clearSynchronization,
 	);
-	return { ...mutation, resetStaleStateError };
+	return {
+		...mutation,
+		resetStaleStateError,
+		isStaleStateSynchronized: staleStateSynchronization.isSynchronized,
+	};
 }
 
 export function useCompleteHabitMutation(
@@ -214,13 +276,16 @@ export function useCompleteHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
 	const queryClient = useQueryClient();
-	const staleStateSynchronized = useRef(false);
+	const staleStateSynchronization = useStaleStateSynchronization();
 	const mutation = useMutation({
 		mutationKey: habitMutationKey(habitId, "complete"),
 		mutationFn: () => completeHabitRequest(habitId),
-		onMutate: () => ({
-			refetchAfterComplete: hasInvalidatedHomeRefetch(queryClient),
-		}),
+		onMutate: () => {
+			staleStateSynchronization.clearSynchronization();
+			return {
+				refetchAfterComplete: hasInvalidatedHomeRefetch(queryClient),
+			};
+		},
 		onSuccess: (response, _variables, context) => {
 			const refetchAfterComplete =
 				context?.refetchAfterComplete || hasInvalidatedHomeRefetch(queryClient);
@@ -235,20 +300,28 @@ export function useCompleteHabitMutation(
 			}
 		},
 		onError: (error) => {
-			staleStateSynchronized.current = false;
+			const sequence = staleStateSynchronization.beginSynchronization();
 			void synchronizeMutationError(
 				queryClient,
 				error,
 				options.onUnauthorized,
 			).then((synchronized) => {
-				staleStateSynchronized.current = synchronized;
+				staleStateSynchronization.completeSynchronization(
+					sequence,
+					synchronized,
+				);
 			});
 		},
 	});
 	const resetStaleStateError = useStaleStateErrorReset(
 		mutation.error,
 		mutation.reset,
-		staleStateSynchronized,
+		staleStateSynchronization.synchronizedRef,
+		staleStateSynchronization.clearSynchronization,
 	);
-	return { ...mutation, resetStaleStateError };
+	return {
+		...mutation,
+		resetStaleStateError,
+		isStaleStateSynchronized: staleStateSynchronization.isSynchronized,
+	};
 }

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -83,12 +83,14 @@ function useStaleStateErrorReset(
  */
 function useStaleStateSynchronization() {
 	const [isSynchronized, setIsSynchronized] = useState(false);
+	const [isSynchronizing, setIsSynchronizing] = useState(false);
 	const synchronizedRef = useRef(false);
 	const sequenceRef = useRef(0);
 	const beginSynchronization = useCallback(() => {
 		sequenceRef.current += 1;
 		synchronizedRef.current = false;
 		setIsSynchronized(false);
+		setIsSynchronizing(true);
 		return sequenceRef.current;
 	}, []);
 	const completeSynchronization = useCallback(
@@ -96,6 +98,7 @@ function useStaleStateSynchronization() {
 			if (sequence === sequenceRef.current) {
 				synchronizedRef.current = synchronized;
 				setIsSynchronized(synchronized);
+				setIsSynchronizing(false);
 			}
 		},
 		[],
@@ -104,15 +107,36 @@ function useStaleStateSynchronization() {
 		sequenceRef.current += 1;
 		synchronizedRef.current = false;
 		setIsSynchronized(false);
+		setIsSynchronizing(false);
 	}, []);
 
 	return {
 		isSynchronized,
+		isSynchronizing,
 		synchronizedRef,
 		beginSynchronization,
 		completeSynchronization,
 		clearSynchronization,
 	};
+}
+
+function synchronizeStaleStateError(
+	queryClient: QueryClient,
+	error: unknown,
+	onUnauthorized: (() => void | Promise<void>) | undefined,
+	staleStateSynchronization: ReturnType<typeof useStaleStateSynchronization>,
+): void {
+	if (!isStaleStateError(error)) {
+		void synchronizeMutationError(queryClient, error, onUnauthorized);
+		return;
+	}
+
+	const sequence = staleStateSynchronization.beginSynchronization();
+	void synchronizeMutationError(queryClient, error, onUnauthorized).then(
+		(synchronized) => {
+			staleStateSynchronization.completeSynchronization(sequence, synchronized);
+		},
+	);
 }
 
 async function synchronizeMutationError(
@@ -205,17 +229,12 @@ export function useUpdateHabitMutation(
 		},
 		onSuccess: () => invalidateAndRefetchHome(queryClient),
 		onError: (error) => {
-			const sequence = staleStateSynchronization.beginSynchronization();
-			void synchronizeMutationError(
+			synchronizeStaleStateError(
 				queryClient,
 				error,
 				options.onUnauthorized,
-			).then((synchronized) => {
-				staleStateSynchronization.completeSynchronization(
-					sequence,
-					synchronized,
-				);
-			});
+				staleStateSynchronization,
+			);
 		},
 	});
 	const resetStaleStateError = useStaleStateErrorReset(
@@ -228,6 +247,7 @@ export function useUpdateHabitMutation(
 		...mutation,
 		resetStaleStateError,
 		isStaleStateSynchronized: staleStateSynchronization.isSynchronized,
+		isStaleStateSynchronizing: staleStateSynchronization.isSynchronizing,
 	};
 }
 
@@ -245,17 +265,12 @@ export function useArchiveHabitMutation(
 		},
 		onSuccess: () => invalidateAndRefetchHome(queryClient),
 		onError: (error) => {
-			const sequence = staleStateSynchronization.beginSynchronization();
-			void synchronizeMutationError(
+			synchronizeStaleStateError(
 				queryClient,
 				error,
 				options.onUnauthorized,
-			).then((synchronized) => {
-				staleStateSynchronization.completeSynchronization(
-					sequence,
-					synchronized,
-				);
-			});
+				staleStateSynchronization,
+			);
 		},
 	});
 	const resetStaleStateError = useStaleStateErrorReset(
@@ -268,6 +283,7 @@ export function useArchiveHabitMutation(
 		...mutation,
 		resetStaleStateError,
 		isStaleStateSynchronized: staleStateSynchronization.isSynchronized,
+		isStaleStateSynchronizing: staleStateSynchronization.isSynchronizing,
 	};
 }
 
@@ -300,17 +316,12 @@ export function useCompleteHabitMutation(
 			}
 		},
 		onError: (error) => {
-			const sequence = staleStateSynchronization.beginSynchronization();
-			void synchronizeMutationError(
+			synchronizeStaleStateError(
 				queryClient,
 				error,
 				options.onUnauthorized,
-			).then((synchronized) => {
-				staleStateSynchronization.completeSynchronization(
-					sequence,
-					synchronized,
-				);
-			});
+				staleStateSynchronization,
+			);
 		},
 	});
 	const resetStaleStateError = useStaleStateErrorReset(
@@ -323,5 +334,6 @@ export function useCompleteHabitMutation(
 		...mutation,
 		resetStaleStateError,
 		isStaleStateSynchronized: staleStateSynchronization.isSynchronized,
+		isStaleStateSynchronizing: staleStateSynchronization.isSynchronizing,
 	};
 }

--- a/web-app/src/features/habits/today-summary.tsx
+++ b/web-app/src/features/habits/today-summary.tsx
@@ -1,0 +1,20 @@
+import type { HomeHabit } from "~/features/home/home.contract";
+
+export function TodaySummary({ habits }: { habits: readonly HomeHabit[] }) {
+	if (habits.length === 0) {
+		return null;
+	}
+
+	const completedCount = habits.filter(
+		(habit) => habit.isCompletedToday,
+	).length;
+	return (
+		<p
+			aria-live="polite"
+			className="text-sm font-medium text-stone-600"
+			data-testid="today-summary"
+		>
+			{completedCount} / {habits.length} 完了
+		</p>
+	);
+}


### PR DESCRIPTION
## 概要

ホーム画面で再利用するTodaySummary、HabitList、HabitCard、CompleteButtonを実装し、既存complete mutation基盤へ接続しました。

Closes #38

## 変更内容

- API返却順を保つ習慣一覧、完了数サマリー、空状態を追加
- 絵文字有無、現在/最長streak、未達成/達成済みcardを日本語で表示
- mobile全幅・desktop自動幅の達成ボタンと、card単位pending/二重送信防止を実装
- 同一habitのupdate/archive/complete pendingを共有し、別habitは操作可能
- complete成功responseの3フィールドからcard/summaryを更新し、Activity Logは不変
- 401をglobal authへ委譲し、network/5xx/stale-state errorをcard付近の`role="alert"`へ表示
- stale-state errorを成功したhome再同期後だけ反応的に消去し、古い再同期結果の競合を防止
- pendingのaccessible name/`aria-busy`とsummaryのlive regionを追加
- 後続Issue向けの非機能な操作メニューは追加していません

## 確認

- `pnpm test`（17 files / 136 tests）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`

ローカルNode 20ではNode 26 engine warningが出ますが、GitHub CIはrepository指定のNode 26を使用します。
