### PR TITLE
習慣追加ダイアログを実装

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -30,6 +30,7 @@
 		"db:studio": "drizzle-kit studio"
 	},
 	"dependencies": {
+		"@radix-ui/react-dialog": "^1.1.23",
 		"@tanstack/react-query": "^5.101.4",
 		"@tanstack/react-router": "^1.170.18",
 		"@tanstack/react-start": "^1.168.32",

--- a/web-app/pnpm-lock.yaml
+++ b/web-app/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.23
+        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
@@ -1120,6 +1123,168 @@ packages:
   '@oxc-project/types@0.137.0':
     resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
 
+  '@radix-ui/primitive@1.1.7':
+    resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
+
+  '@radix-ui/react-compose-refs@1.1.5':
+    resolution: {integrity: sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.2':
+    resolution: {integrity: sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.23':
+    resolution: {integrity: sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.19':
+    resolution: {integrity: sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.6':
+    resolution: {integrity: sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.16':
+    resolution: {integrity: sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.4':
+    resolution: {integrity: sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.17':
+    resolution: {integrity: sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.10':
+    resolution: {integrity: sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.10':
+    resolution: {integrity: sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.3':
+    resolution: {integrity: sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.4':
+    resolution: {integrity: sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.6':
+    resolution: {integrity: sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.5':
+    resolution: {integrity: sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.4':
+    resolution: {integrity: sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rolldown/binding-android-arm64@1.1.2':
     resolution: {integrity: sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1694,6 +1859,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -1895,6 +2064,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -2093,6 +2265,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -2463,6 +2639,36 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -2753,6 +2959,26 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -3645,6 +3871,143 @@ snapshots:
 
   '@oxc-project/types@0.137.0': {}
 
+  '@radix-ui/primitive@1.1.7': {}
+
+  '@radix-ui/react-compose-refs@1.1.5(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-context@1.2.2(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      aria-hidden: 1.2.6
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-focus-guards@1.1.6(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-focus-scope@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-id@1.1.4(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-portal@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-presence@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-primitive@2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-slot@1.3.3(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-callback-ref@1.1.4(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-controllable-state@1.2.6(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-effect-event@0.0.5(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-layout-effect@1.1.4(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@rolldown/binding-android-arm64@1.1.2':
     optional: true
 
@@ -4212,6 +4575,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -4345,6 +4712,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   diff@8.0.4: {}
 
@@ -4522,6 +4891,8 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-nonce@1.0.1: {}
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -4831,6 +5202,33 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.8)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.8)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.8)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.8)
+      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.8):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.8
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   react@19.2.8: {}
 
   readdirp@5.0.0: {}
@@ -4981,8 +5379,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.23.1:
     dependencies:
@@ -5030,6 +5427,21 @@ snapshots:
       browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.8):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.8
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:

--- a/web-app/src/features/habits/add-habit-dialog.test.tsx
+++ b/web-app/src/features/habits/add-habit-dialog.test.tsx
@@ -1,0 +1,359 @@
+import {
+	QueryClient,
+	QueryClientProvider,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HomeDataResponse } from "~/features/home/home.contract";
+import { homeQueryOptions } from "~/features/home/home.query";
+import { AddHabitDialog } from "./add-habit-dialog";
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("AddHabitDialog", () => {
+	it("タスク追加から開き、習慣名へinitial focusを当ててアクセシブルな関連付けを持つ", async () => {
+		const user = userEvent.setup();
+		renderWithClient(<AddHabitDialog />);
+
+		const trigger = screen.getByRole("button", { name: "+ タスク追加" });
+		await user.click(trigger);
+
+		expect(
+			screen.getByRole("dialog", { name: "習慣を追加" }),
+		).toBeInTheDocument();
+		expect(screen.getByLabelText("習慣名")).toHaveFocus();
+		expect(screen.getByLabelText("絵文字（任意）")).toHaveAttribute(
+			"placeholder",
+			"例: 📚",
+		);
+		expect(
+			screen.getByText("毎日続けたい習慣を登録します。"),
+		).toBeInTheDocument();
+		expect(screen.getByLabelText("習慣名")).not.toHaveAttribute("maxLength");
+		expect(screen.getByLabelText("絵文字（任意）")).not.toHaveAttribute(
+			"maxLength",
+		);
+	});
+
+	it("空文字・空白のみ・51グラフェムを検証し、失敗時はAPIを呼ばない", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal("fetch", fetchMock);
+		renderWithClient(<AddHabitDialog />);
+		await openDialog(user);
+
+		await user.click(screen.getByRole("button", { name: "追加" }));
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"習慣名を入力してください",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+
+		const name = screen.getByLabelText("習慣名");
+		await user.type(name, "読書");
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		await user.clear(name);
+		await user.type(name, "   ");
+		await user.click(screen.getByRole("button", { name: "追加" }));
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"習慣名を入力してください",
+		);
+
+		await user.clear(name);
+		await user.type(name, "🌱".repeat(51));
+		await user.click(screen.getByRole("button", { name: "追加" }));
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"習慣名は50文字以内で入力してください",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("50グラフェム、通常・ZWJ・skin tone付きemojiを受け付ける", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation(() =>
+				Promise.resolve(jsonResponse(habitResponse)),
+			),
+		);
+		renderWithClient(<AddHabitDialog />);
+
+		for (const emoji of ["📚", "👨‍👩‍👧‍👦", "👍🏽"]) {
+			await openDialog(user);
+			await user.type(screen.getByLabelText("習慣名"), "🌱".repeat(50));
+			await user.type(screen.getByLabelText("絵文字（任意）"), emoji);
+			await user.click(screen.getByRole("button", { name: "追加" }));
+			await vi.waitFor(() =>
+				expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+			);
+		}
+
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	it("複数絵文字と非絵文字を検証し、該当fieldの編集でerrorを消す", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal("fetch", fetchMock);
+		renderWithClient(<AddHabitDialog />);
+		await openDialog(user);
+		await user.type(screen.getByLabelText("習慣名"), "読書");
+		const emoji = screen.getByLabelText("絵文字（任意）");
+		await user.type(emoji, "📚📖");
+		await user.click(screen.getByRole("button", { name: "追加" }));
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"絵文字は1つだけ入力してください",
+		);
+		expect(emoji).toHaveAttribute("aria-invalid", "true");
+		expect(emoji).toHaveAttribute("aria-describedby", "add-habit-emoji-error");
+
+		await user.clear(emoji);
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		await user.type(emoji, "読");
+		await user.click(screen.getByRole("button", { name: "追加" }));
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"絵文字を1つだけ入力してください",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("trim済みpayloadをPOSTし、成功後にhomeを再取得してから閉じる", async () => {
+		const user = userEvent.setup();
+		let homeRequestCount = 0;
+		let resolveHomeRefetch: ((response: Response) => void) | undefined;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					if (homeRequestCount === 1) {
+						return Promise.resolve(jsonResponse(homeData));
+					}
+					return new Promise<Response>((resolve) => {
+						resolveHomeRefetch = resolve;
+					});
+				}
+				return Promise.resolve(jsonResponse(habitResponse));
+			}),
+		);
+		renderWithClient(<AddHabitDialogWithActiveHome />);
+		await vi.waitFor(() => expect(homeRequestCount).toBe(1));
+		await openDialog(user);
+		await user.type(screen.getByLabelText("習慣名"), "  読書  ");
+		await user.type(screen.getByLabelText("絵文字（任意）"), "📚");
+		await user.click(screen.getByRole("button", { name: "追加" }));
+
+		await vi.waitFor(() => expect(homeRequestCount).toBe(2));
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "追加しています…" }),
+		).toBeDisabled();
+		resolveHomeRefetch?.(jsonResponse(homeData));
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/habits",
+			expect.objectContaining({
+				body: JSON.stringify({ name: "読書", emoji: "📚" }),
+				method: "POST",
+			}),
+		);
+	});
+
+	it("pending中は二重送信とEsc・外側clickによるcloseを防ぎ、操作をdisabledにする", async () => {
+		const user = userEvent.setup();
+		const create = deferred<Response>();
+		vi.stubGlobal("fetch", fetchMock.mockReturnValue(create.promise));
+		renderWithClient(<AddHabitDialog />);
+		await openDialog(user);
+		await user.type(screen.getByLabelText("習慣名"), "読書");
+		const submit = screen.getByRole("button", { name: "追加" });
+		await user.dblClick(submit);
+
+		await vi.waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: "追加しています…" }),
+			).toBeDisabled(),
+		);
+		expect(screen.getByLabelText("習慣名")).toBeDisabled();
+		expect(screen.getByLabelText("絵文字（任意）")).toBeDisabled();
+		expect(screen.getByRole("button", { name: "キャンセル" })).toBeDisabled();
+		expect(
+			fetchMock.mock.calls.filter(([path]) => path === "/api/habits"),
+		).toHaveLength(1);
+
+		await user.keyboard("{Escape}");
+		await user.click(dialogOverlay());
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+		await act(async () => {
+			create.resolve(jsonResponse(habitResponse));
+		});
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+	});
+
+	it.each([
+		["HABIT_LIMIT_EXCEEDED", 409, "これ以上、習慣を作成できません"],
+		[
+			"INTERNAL_SERVER_ERROR",
+			500,
+			"処理に失敗しました。時間をおいて再試行してください",
+		],
+		["INVALID_REQUEST", 400, "安全なAPIメッセージ"],
+	] as const)(
+		"%s の失敗ではDialogと入力を維持してエラーを表示する",
+		async (code, status, message) => {
+			const user = userEvent.setup();
+			vi.stubGlobal(
+				"fetch",
+				fetchMock.mockResolvedValue(jsonResponse({ code, message }, status)),
+			);
+			renderWithClient(<AddHabitDialog />);
+			await openDialog(user);
+			await user.type(screen.getByLabelText("習慣名"), "読書");
+			await user.click(screen.getByRole("button", { name: "追加" }));
+
+			expect(await screen.findByRole("alert")).toHaveTextContent(message);
+			expect(screen.getByRole("dialog")).toBeInTheDocument();
+			expect(screen.getByLabelText("習慣名")).toHaveValue("読書");
+		},
+	);
+
+	it("network errorを表示し、401はDialog内alertを出さずglobal auth handlingへ委譲する", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal("fetch", fetchMock.mockRejectedValue(new Error("offline")));
+		renderWithClient(<AddHabitDialog />);
+		await openDialog(user);
+		await user.type(screen.getByLabelText("習慣名"), "読書");
+		await user.click(screen.getByRole("button", { name: "追加" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"通信に失敗しました。接続を確認して再試行してください",
+		);
+
+		cleanup();
+		const onUnauthorized = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValue(
+				jsonResponse(
+					{ code: "UNAUTHORIZED", message: "ログインが必要です。" },
+					401,
+				),
+			),
+		);
+		renderWithClient(<AddHabitDialog onUnauthorized={onUnauthorized} />);
+		await openDialog(user);
+		await user.type(screen.getByLabelText("習慣名"), "読書");
+		await user.click(screen.getByRole("button", { name: "追加" }));
+		await vi.waitFor(() => expect(onUnauthorized).toHaveBeenCalledTimes(1));
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("通常のCancel・Esc・外側clickは値とerrorをresetし、triggerへfocusを戻す", async () => {
+		const user = userEvent.setup();
+		renderWithClient(<AddHabitDialog />);
+		const trigger = screen.getByRole("button", { name: "+ タスク追加" });
+
+		await openDialog(user);
+		await user.type(screen.getByLabelText("習慣名"), "読書");
+		await user.click(screen.getByRole("button", { name: "キャンセル" }));
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+		expect(trigger).toHaveFocus();
+
+		await openDialog(user);
+		expect(screen.getByLabelText("習慣名")).toHaveValue("");
+		await user.type(screen.getByLabelText("習慣名"), "読書");
+		await user.keyboard("{Escape}");
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+		expect(trigger).toHaveFocus();
+
+		await openDialog(user);
+		await user.type(screen.getByLabelText("習慣名"), "読書");
+		await user.click(dialogOverlay());
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+		expect(trigger).toHaveFocus();
+		await openDialog(user);
+		expect(screen.getByLabelText("習慣名")).toHaveValue("");
+	});
+});
+
+function AddHabitDialogWithActiveHome() {
+	const queryClient = useQueryClient();
+	useQuery(homeQueryOptions({ enabled: true }, queryClient));
+	return <AddHabitDialog />;
+}
+
+function openDialog(user: ReturnType<typeof userEvent.setup>) {
+	return user.click(screen.getByRole("button", { name: "+ タスク追加" }));
+}
+
+function dialogOverlay(): HTMLElement {
+	const overlay = screen.getByRole("dialog").previousElementSibling;
+	if (!(overlay instanceof HTMLElement)) {
+		throw new Error("Dialog overlay was not rendered.");
+	}
+	return overlay;
+}
+
+function renderWithClient(ui: React.ReactElement) {
+	return render(ui, { wrapper: wrapper(createQueryClient()) });
+}
+
+function wrapper(queryClient: QueryClient) {
+	return function QueryWrapper({ children }: PropsWithChildren) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+function createQueryClient(): QueryClient {
+	return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+const habitResponse = {
+	id: "habit-1",
+	name: "読書",
+	emoji: "📚",
+	currentStreak: 0,
+	maxStreak: 0,
+	createdAt: "2026-08-08T12:00:00+09:00",
+	archivedAt: null,
+};
+
+const homeData: HomeDataResponse = {
+	habits: [],
+	activityLog: [{ date: "2026-08-08", completionRate: null }],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}

--- a/web-app/src/features/habits/add-habit-dialog.tsx
+++ b/web-app/src/features/habits/add-habit-dialog.tsx
@@ -1,0 +1,275 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { useCallback, useRef, useState } from "react";
+import { ApiClientError } from "~/lib/api/client";
+import { validateHabitEmoji, validateHabitName } from "./habit-validation";
+import { useCreateHabitMutation } from "./habits.mutations";
+
+type FieldErrors = {
+	name?: string;
+	emoji?: string;
+};
+
+type AddHabitDialogProps = {
+	onUnauthorized?: () => void | Promise<void>;
+};
+
+function getNameError(value: string): string | undefined {
+	const result = validateHabitName(value);
+	if (result.isValid) {
+		return undefined;
+	}
+	return result.reason === "required"
+		? "習慣名を入力してください"
+		: "習慣名は50文字以内で入力してください";
+}
+
+function getEmojiError(value: string): string | undefined {
+	const result = validateHabitEmoji(value);
+	if (result.isValid) {
+		return undefined;
+	}
+	return result.reason === "multiple"
+		? "絵文字は1つだけ入力してください"
+		: "絵文字を1つだけ入力してください";
+}
+
+export function getAddHabitErrorMessage(error: unknown): string | null {
+	if (!(error instanceof ApiClientError)) {
+		return "通信に失敗しました。接続を確認して再試行してください";
+	}
+	if (error.status === 401) {
+		return null;
+	}
+	if (error.status === null) {
+		return "通信に失敗しました。接続を確認して再試行してください";
+	}
+	switch (error.code) {
+		case "INVALID_REQUEST":
+			return error.message || "リクエスト内容が不正です。";
+		case "HABIT_LIMIT_EXCEEDED":
+			return "これ以上、習慣を作成できません";
+		case "INTERNAL_SERVER_ERROR":
+			return "処理に失敗しました。時間をおいて再試行してください";
+		default:
+			return error.status >= 500
+				? "処理に失敗しました。時間をおいて再試行してください"
+				: "処理に失敗しました。時間をおいて再試行してください";
+	}
+}
+
+export function AddHabitDialog({ onUnauthorized }: AddHabitDialogProps) {
+	const [open, setOpen] = useState(false);
+	const [name, setName] = useState("");
+	const [emoji, setEmoji] = useState("");
+	const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+	const [submitError, setSubmitError] = useState<string | null>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const nameInputRef = useRef<HTMLInputElement>(null);
+	const submitInFlight = useRef(false);
+	const mutation = useCreateHabitMutation({ onUnauthorized });
+	const isPending = mutation.isPending;
+
+	const resetForm = useCallback(() => {
+		setName("");
+		setEmoji("");
+		setFieldErrors({});
+		setSubmitError(null);
+		mutation.reset();
+	}, [mutation.reset]);
+
+	const closeAndReset = useCallback(() => {
+		if (isPending || submitInFlight.current) {
+			return;
+		}
+		setOpen(false);
+		resetForm();
+	}, [isPending, resetForm]);
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		if (nextOpen) {
+			setOpen(true);
+			return;
+		}
+		closeAndReset();
+	};
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (isPending || submitInFlight.current) {
+			return;
+		}
+
+		const nameError = getNameError(name);
+		const emojiError = getEmojiError(emoji);
+		if (nameError || emojiError) {
+			setFieldErrors({ name: nameError, emoji: emojiError });
+			setSubmitError(null);
+			return;
+		}
+
+		const validatedName = validateHabitName(name);
+		const validatedEmoji = validateHabitEmoji(emoji);
+		if (!validatedName.isValid || !validatedEmoji.isValid) {
+			return;
+		}
+
+		setFieldErrors({});
+		setSubmitError(null);
+		submitInFlight.current = true;
+		try {
+			await mutation.mutateAsync({
+				name: validatedName.value,
+				emoji: validatedEmoji.value,
+			});
+			setOpen(false);
+			resetForm();
+		} catch (error) {
+			setSubmitError(getAddHabitErrorMessage(error));
+		} finally {
+			submitInFlight.current = false;
+		}
+	};
+
+	return (
+		<Dialog.Root open={open} onOpenChange={handleOpenChange}>
+			<Dialog.Trigger asChild>
+				<button
+					className="inline-flex cursor-pointer items-center justify-center rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-100 disabled:text-emerald-900"
+					ref={triggerRef}
+					type="button"
+				>
+					+ タスク追加
+				</button>
+			</Dialog.Trigger>
+			<Dialog.Portal>
+				<Dialog.Overlay className="fixed inset-0 bg-stone-950/30" />
+				<Dialog.Content
+					aria-busy={isPending || undefined}
+					className="fixed top-1/2 left-1/2 max-h-[calc(100vh-2rem)] w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-xl border border-stone-200 bg-white p-6 shadow-xl focus:outline-none"
+					onCloseAutoFocus={(event) => {
+						event.preventDefault();
+						triggerRef.current?.focus();
+					}}
+					onEscapeKeyDown={(event) => {
+						if (isPending || submitInFlight.current) {
+							event.preventDefault();
+						}
+					}}
+					onInteractOutside={(event) => {
+						if (isPending || submitInFlight.current) {
+							event.preventDefault();
+						}
+					}}
+					onOpenAutoFocus={(event) => {
+						event.preventDefault();
+						nameInputRef.current?.focus();
+					}}
+				>
+					<Dialog.Title className="text-lg font-semibold text-stone-950">
+						習慣を追加
+					</Dialog.Title>
+					<Dialog.Description className="mt-1 text-sm text-stone-600">
+						毎日続けたい習慣を登録します。
+					</Dialog.Description>
+					<form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+						<div>
+							<label
+								className="block text-sm font-medium text-stone-900"
+								htmlFor="add-habit-name"
+							>
+								習慣名
+							</label>
+							<input
+								aria-describedby={
+									fieldErrors.name ? "add-habit-name-error" : undefined
+								}
+								aria-invalid={fieldErrors.name ? true : undefined}
+								className="mt-1 w-full rounded-lg border border-stone-300 bg-white px-3 py-2 text-stone-950 shadow-sm outline-none placeholder:text-stone-400 focus:border-emerald-700 focus:ring-2 focus:ring-emerald-100 disabled:cursor-not-allowed disabled:bg-stone-100"
+								disabled={isPending}
+								id="add-habit-name"
+								onChange={(event) => {
+									setName(event.target.value);
+									setFieldErrors((current) => ({
+										...current,
+										name: undefined,
+									}));
+									setSubmitError(null);
+								}}
+								ref={nameInputRef}
+								value={name}
+							/>
+							{fieldErrors.name ? (
+								<p
+									className="mt-1 text-sm text-red-700"
+									id="add-habit-name-error"
+									role="alert"
+								>
+									{fieldErrors.name}
+								</p>
+							) : null}
+						</div>
+						<div>
+							<label
+								className="block text-sm font-medium text-stone-900"
+								htmlFor="add-habit-emoji"
+							>
+								絵文字（任意）
+							</label>
+							<input
+								aria-describedby={
+									fieldErrors.emoji ? "add-habit-emoji-error" : undefined
+								}
+								aria-invalid={fieldErrors.emoji ? true : undefined}
+								className="mt-1 w-full rounded-lg border border-stone-300 bg-white px-3 py-2 text-stone-950 shadow-sm outline-none placeholder:text-stone-400 focus:border-emerald-700 focus:ring-2 focus:ring-emerald-100 disabled:cursor-not-allowed disabled:bg-stone-100"
+								disabled={isPending}
+								id="add-habit-emoji"
+								onChange={(event) => {
+									setEmoji(event.target.value);
+									setFieldErrors((current) => ({
+										...current,
+										emoji: undefined,
+									}));
+									setSubmitError(null);
+								}}
+								placeholder="例: 📚"
+								value={emoji}
+							/>
+							{fieldErrors.emoji ? (
+								<p
+									className="mt-1 text-sm text-red-700"
+									id="add-habit-emoji-error"
+									role="alert"
+								>
+									{fieldErrors.emoji}
+								</p>
+							) : null}
+						</div>
+						{submitError ? (
+							<p className="text-sm text-red-700" role="alert">
+								{submitError}
+							</p>
+						) : null}
+						<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+							<button
+								className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-stone-300 bg-white px-4 py-2.5 text-sm font-semibold text-stone-800 shadow-sm transition hover:bg-stone-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-stone-100 disabled:text-stone-500"
+								disabled={isPending}
+								onClick={closeAndReset}
+								type="button"
+							>
+								キャンセル
+							</button>
+							<button
+								aria-busy={isPending || undefined}
+								className="inline-flex cursor-pointer items-center justify-center rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-100 disabled:text-emerald-900"
+								disabled={isPending}
+								type="submit"
+							>
+								{isPending ? "追加しています…" : "追加"}
+							</button>
+						</div>
+					</form>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/web-app/src/features/habits/habit-validation.test.ts
+++ b/web-app/src/features/habits/habit-validation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+	countGraphemes,
+	isSingleEmojiGrapheme,
+	validateHabitEmoji,
+	validateHabitName,
+} from "./habit-validation";
+
+describe("habit-validation", () => {
+	it("50グラフェムの習慣名を受け付け、51グラフェムを拒否する", () => {
+		expect(validateHabitName("🌱".repeat(50))).toEqual({
+			isValid: true,
+			value: "🌱".repeat(50),
+		});
+		expect(validateHabitName("🌱".repeat(51))).toEqual({
+			isValid: false,
+			reason: "tooLong",
+		});
+	});
+
+	it("空文字と空白のみの習慣名を拒否し、trim後の値を返す", () => {
+		expect(validateHabitName("")).toEqual({
+			isValid: false,
+			reason: "required",
+		});
+		expect(validateHabitName("  \t ")).toEqual({
+			isValid: false,
+			reason: "required",
+		});
+		expect(validateHabitName("  読書  ")).toEqual({
+			isValid: true,
+			value: "読書",
+		});
+	});
+
+	it.each(["📚", "👨‍👩‍👧‍👦", "👍🏽", "🇯🇵", "1️⃣", "❤️"])(
+		"RGI Emoji %s をひとつのグラフェムとして受け付ける",
+		(emoji) => {
+			expect(countGraphemes(emoji)).toBe(1);
+			expect(isSingleEmojiGrapheme(emoji)).toBe(true);
+			expect(validateHabitEmoji(emoji)).toEqual({
+				isValid: true,
+				value: emoji,
+			});
+		},
+	);
+
+	it("空の絵文字を受け付け、複数または非絵文字を拒否する", () => {
+		expect(validateHabitEmoji("")).toEqual({ isValid: true, value: "" });
+		expect(validateHabitEmoji("📚📖")).toEqual({
+			isValid: false,
+			reason: "multiple",
+		});
+		expect(validateHabitEmoji("読")).toEqual({
+			isValid: false,
+			reason: "notEmoji",
+		});
+	});
+});

--- a/web-app/src/features/habits/habit-validation.ts
+++ b/web-app/src/features/habits/habit-validation.ts
@@ -1,0 +1,49 @@
+export const HABIT_NAME_MAX_GRAPHEMES = 50;
+
+const graphemeSegmenter = new Intl.Segmenter("ja", {
+	granularity: "grapheme",
+});
+// biome-ignore lint/complexity/useRegexLiterals: ES2022 targetでvフラグを使用するためコンストラクタ形式にする。
+const emojiPattern = new RegExp("^\\p{RGI_Emoji}$", "v");
+
+export function countGraphemes(value: string): number {
+	return [...graphemeSegmenter.segment(value)].length;
+}
+
+export function isSingleEmojiGrapheme(value: string): boolean {
+	return emojiPattern.test(value);
+}
+
+export type HabitNameValidation =
+	| { isValid: true; value: string }
+	| { isValid: false; reason: "required" | "tooLong" };
+
+/** server と form の両方で使う、trim 後の習慣名の検証。 */
+export function validateHabitName(value: string): HabitNameValidation {
+	const trimmedValue = value.trim();
+	if (trimmedValue === "") {
+		return { isValid: false, reason: "required" };
+	}
+	if (countGraphemes(trimmedValue) > HABIT_NAME_MAX_GRAPHEMES) {
+		return { isValid: false, reason: "tooLong" };
+	}
+	return { isValid: true, value: trimmedValue };
+}
+
+export type HabitEmojiValidation =
+	| { isValid: true; value: string }
+	| { isValid: false; reason: "multiple" | "notEmoji" };
+
+/** 空文字または RGI Emoji ひとつを受け付ける。emoji は trim しない。 */
+export function validateHabitEmoji(value: string): HabitEmojiValidation {
+	if (value === "") {
+		return { isValid: true, value };
+	}
+	if (countGraphemes(value) > 1) {
+		return { isValid: false, reason: "multiple" };
+	}
+	if (!isSingleEmojiGrapheme(value)) {
+		return { isValid: false, reason: "notEmoji" };
+	}
+	return { isValid: true, value };
+}

--- a/web-app/src/features/habits/habits.contract.test.ts
+++ b/web-app/src/features/habits/habits.contract.test.ts
@@ -65,6 +65,14 @@ describe("parseCreateHabitRequest", () => {
 		const name = "🌱".repeat(50);
 		expect(parseCreateHabitRequest({ name })).toEqual({ name, emoji: "" });
 	});
+
+	it("51グラフェムの習慣名を拒否する", () => {
+		expect(() =>
+			parseCreateHabitRequest({ name: "🌱".repeat(51) }),
+		).toThrowError(
+			expect.objectContaining({ code: "INVALID_REQUEST", status: 400 }),
+		);
+	});
 });
 
 describe("parseUpdateHabitRequest", () => {
@@ -133,5 +141,13 @@ describe("parseUpdateHabitRequest", () => {
 	it("50グラフェムの習慣名を受け付ける", () => {
 		const name = "🌱".repeat(50);
 		expect(parseUpdateHabitRequest({ name })).toEqual({ name });
+	});
+
+	it("51グラフェムの習慣名を拒否する", () => {
+		expect(() =>
+			parseUpdateHabitRequest({ name: "🌱".repeat(51) }),
+		).toThrowError(
+			expect.objectContaining({ code: "INVALID_REQUEST", status: 400 }),
+		);
 	});
 });

--- a/web-app/src/features/habits/habits.contract.ts
+++ b/web-app/src/features/habits/habits.contract.ts
@@ -1,4 +1,5 @@
 import { ApiError } from "~/lib/api/errors";
+import { validateHabitEmoji, validateHabitName } from "./habit-validation";
 import type {
 	ParsedCreateHabitRequest,
 	UpdateHabitRequest,
@@ -9,11 +10,6 @@ export type {
 	UpdateHabitRequest,
 } from "./habits.api-contract";
 
-const graphemeSegmenter = new Intl.Segmenter("ja", {
-	granularity: "grapheme",
-});
-// biome-ignore lint/complexity/useRegexLiterals: ES2022 targetでvフラグを使用するためコンストラクタ形式にする。
-const emojiPattern = new RegExp("^\\p{RGI_Emoji}$", "v");
 const createHabitFields = new Set(["name", "emoji"]);
 const updateHabitFields = new Set(["name", "emoji"]);
 
@@ -23,14 +19,6 @@ function invalidRequest(cause?: unknown): never {
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function countGraphemes(value: string): number {
-	return [...graphemeSegmenter.segment(value)].length;
-}
-
-function isSingleEmojiGrapheme(value: string): boolean {
-	return emojiPattern.test(value);
 }
 
 export function parseCreateHabitRequest(
@@ -46,20 +34,17 @@ export function parseCreateHabitRequest(
 		return invalidRequest();
 	}
 
-	const name = body.name.trim();
-	if (name === "" || countGraphemes(name) > 50) {
+	const name = validateHabitName(body.name);
+	if (!name.isValid) {
 		return invalidRequest();
 	}
 
 	const emoji = body.emoji === undefined ? "" : body.emoji;
-	if (
-		typeof emoji !== "string" ||
-		(emoji !== "" && !isSingleEmojiGrapheme(emoji))
-	) {
+	if (typeof emoji !== "string" || !validateHabitEmoji(emoji).isValid) {
 		return invalidRequest();
 	}
 
-	return { name, emoji };
+	return { name: name.value, emoji };
 }
 
 export function parseUpdateHabitRequest(body: unknown): UpdateHabitRequest {
@@ -80,17 +65,17 @@ export function parseUpdateHabitRequest(body: unknown): UpdateHabitRequest {
 		if (typeof body.name !== "string") {
 			return invalidRequest();
 		}
-		const name = body.name.trim();
-		if (name === "" || countGraphemes(name) > 50) {
+		const name = validateHabitName(body.name);
+		if (!name.isValid) {
 			return invalidRequest();
 		}
-		request.name = name;
+		request.name = name.value;
 	}
 
 	if ("emoji" in body) {
 		if (
 			typeof body.emoji !== "string" ||
-			(body.emoji !== "" && !isSingleEmojiGrapheme(body.emoji))
+			!validateHabitEmoji(body.emoji).isValid
 		) {
 			return invalidRequest();
 		}


### PR DESCRIPTION
## 概要

`+ タスク追加` から習慣名と任意の絵文字を登録するRadix Dialogを実装し、既存create mutationへ接続しました。

Closes #39

## 変更内容

- `@radix-ui/react-dialog`を追加し、Daily Green側のTailwind stylingでDialogを実装
- `Intl.Segmenter` / RGI Emoji / name trim・50 grapheme検証をpure shared helperへ抽出
- server parserとclient formで同じvalidationを再利用し、server API semanticsは維持
- name initial focus、label/error関連付け、focus trap、triggerへのfocus復帰を実装
- submit時validation、該当field編集時のerror解消、trim済みpayloadを実装
- pending中のinput/submit/cancel無効化、二重submit・Esc・outside close抑止を実装
- success時はhome再取得完了後にclose、API failure時はDialogと入力を維持
- limit/INVALID_REQUEST/500/networkをDialog内表示し、401はglobal authへ委譲
- 通常のCancel/Esc/outside closeで値とerrorをreset

## 確認

- `pnpm test`（19 files / 158 tests）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`

ローカルNode 20ではNode 26 engine warningが出ますが、GitHub CIはrepository指定のNode 26を使用します。
