### PR TITLE
習慣編集・アーカイブUIを実装

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -31,6 +31,7 @@
 	},
 	"dependencies": {
 		"@radix-ui/react-dialog": "^1.1.23",
+		"@radix-ui/react-dropdown-menu": "^2.1.15",
 		"@tanstack/react-query": "^5.101.4",
 		"@tanstack/react-router": "^1.170.18",
 		"@tanstack/react-start": "^1.168.32",

--- a/web-app/pnpm-lock.yaml
+++ b/web-app/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.23
         version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.15
+        version: 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
@@ -1070,6 +1073,21 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1126,6 +1144,32 @@ packages:
   '@radix-ui/primitive@1.1.7':
     resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
 
+  '@radix-ui/react-arrow@1.1.15':
+    resolution: {integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.15':
+    resolution: {integrity: sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.5':
     resolution: {integrity: sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==}
     peerDependencies:
@@ -1157,8 +1201,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-direction@1.1.4':
+    resolution: {integrity: sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.19':
     resolution: {integrity: sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.24':
+    resolution: {integrity: sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1201,6 +1267,32 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-menu@2.1.24':
+    resolution: {integrity: sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.7':
+    resolution: {integrity: sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.17':
     resolution: {integrity: sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==}
     peerDependencies:
@@ -1229,6 +1321,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.10':
     resolution: {integrity: sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.19':
+    resolution: {integrity: sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1276,6 +1381,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-is-hydrated@0.1.3':
+    resolution: {integrity: sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.1.4':
     resolution: {integrity: sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==}
     peerDependencies:
@@ -1284,6 +1398,27 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-use-rect@1.1.4':
+    resolution: {integrity: sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.4':
+    resolution: {integrity: sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.3':
+    resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
   '@rolldown/binding-android-arm64@1.1.2':
     resolution: {integrity: sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==}
@@ -3820,6 +3955,23 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@floating-ui/utils@0.2.12': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3873,6 +4025,27 @@ snapshots:
 
   '@radix-ui/primitive@1.1.7': {}
 
+  '@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-collection@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-compose-refs@1.1.5(@types/react@19.2.17)(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -3908,6 +4081,12 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-direction@1.1.4(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -3915,6 +4094,21 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-dropdown-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -3945,6 +4139,50 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      aria-hidden: 1.2.6
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-popper@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-rect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/rect': 1.1.3
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-portal@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3967,6 +4205,25 @@ snapshots:
   '@radix-ui/react-primitive@2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -4002,11 +4259,33 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-use-is-hydrated@0.1.3(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-layout-effect@1.1.4(@types/react@19.2.17)(react@19.2.8)':
     dependencies:
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@radix-ui/react-use-rect@1.1.4(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      '@radix-ui/rect': 1.1.3
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-size@1.1.4(@types/react@19.2.17)(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/rect@1.1.3': {}
 
   '@rolldown/binding-android-arm64@1.1.2':
     optional: true

--- a/web-app/src/features/habits/archive-confirm-dialog.tsx
+++ b/web-app/src/features/habits/archive-confirm-dialog.tsx
@@ -12,6 +12,7 @@ type ArchiveConfirmDialogProps = {
 	habit: HomeHabit;
 	open: boolean;
 	triggerRef: React.RefObject<HTMLButtonElement | null>;
+	fallbackFocusRef?: React.RefObject<HTMLElement | null>;
 	onOpenChange: (open: boolean) => void;
 	onUnauthorized?: () => void | Promise<void>;
 };
@@ -20,11 +21,13 @@ export function ArchiveConfirmDialog({
 	habit,
 	open,
 	triggerRef,
+	fallbackFocusRef,
 	onOpenChange,
 	onUnauthorized,
 }: ArchiveConfirmDialogProps) {
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const submitInFlight = useRef(false);
+	const refetchHomeAfterClose = useRef(false);
 	const mountedRef = useRef(true);
 	const wasOpenRef = useRef(false);
 	const mutation = useArchiveHabitMutation(habit.id, { onUnauthorized });
@@ -69,6 +72,7 @@ export function ArchiveConfirmDialog({
 			// 既アーカイブで返る冪等な 200 も通常の成功として閉じる。
 			await mutation.mutateAsync();
 			if (mountedRef.current) {
+				refetchHomeAfterClose.current = true;
 				onOpenChange(false);
 				mutation.reset();
 			}
@@ -95,6 +99,13 @@ export function ArchiveConfirmDialog({
 					onCloseAutoFocus={(event) => {
 						event.preventDefault();
 						triggerRef.current?.focus();
+						if (refetchHomeAfterClose.current) {
+							refetchHomeAfterClose.current = false;
+							void mutation.refetchHome().then(() => {
+								// refetchで対象cardが消えてもfocusをbodyへ落とさない。
+								fallbackFocusRef?.current?.focus();
+							});
+						}
 					}}
 					onEscapeKeyDown={(event) => {
 						if (shouldBlockInteraction()) event.preventDefault();

--- a/web-app/src/features/habits/archive-confirm-dialog.tsx
+++ b/web-app/src/features/habits/archive-confirm-dialog.tsx
@@ -102,8 +102,17 @@ export function ArchiveConfirmDialog({
 						if (refetchHomeAfterClose.current) {
 							refetchHomeAfterClose.current = false;
 							void mutation.refetchHome().then(() => {
-								// refetchで対象cardが消えてもfocusをbodyへ落とさない。
-								fallbackFocusRef?.current?.focus();
+								// Query observerの描画反映後、対象cardの消滅でfocusが失われた
+								// 場合だけfallbackする。refetch中に移動したfocusは奪わない。
+								setTimeout(() => {
+									const activeElement = document.activeElement;
+									const focusWasLost =
+										activeElement === document.body ||
+										!activeElement?.isConnected;
+									if (!triggerRef.current?.isConnected && focusWasLost) {
+										fallbackFocusRef?.current?.focus();
+									}
+								}, 0);
 							});
 						}
 					}}

--- a/web-app/src/features/habits/archive-confirm-dialog.tsx
+++ b/web-app/src/features/habits/archive-confirm-dialog.tsx
@@ -1,0 +1,148 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { useEffect, useRef, useState } from "react";
+import type { HomeHabit } from "~/features/home/home.contract";
+import { getArchiveHabitErrorMessage } from "./habit-dialog-errors";
+import {
+	useArchiveHabitMutation,
+	useIsHabitMutationPending,
+	useIsHabitMutationSynchronizing,
+} from "./habits.mutations";
+
+type ArchiveConfirmDialogProps = {
+	habit: HomeHabit;
+	open: boolean;
+	triggerRef: React.RefObject<HTMLButtonElement | null>;
+	onOpenChange: (open: boolean) => void;
+	onUnauthorized?: () => void | Promise<void>;
+};
+
+export function ArchiveConfirmDialog({
+	habit,
+	open,
+	triggerRef,
+	onOpenChange,
+	onUnauthorized,
+}: ArchiveConfirmDialogProps) {
+	const [submitError, setSubmitError] = useState<string | null>(null);
+	const submitInFlight = useRef(false);
+	const mountedRef = useRef(true);
+	const wasOpenRef = useRef(false);
+	const mutation = useArchiveHabitMutation(habit.id, { onUnauthorized });
+	const isAnyHabitMutationPending = useIsHabitMutationPending(habit.id);
+	const isHabitSynchronizing = useIsHabitMutationSynchronizing(habit.id);
+	const isPending = mutation.isPending || isAnyHabitMutationPending;
+	const blocksClose =
+		isPending || isHabitSynchronizing || submitInFlight.current;
+
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
+	useEffect(() => {
+		if (open && !wasOpenRef.current) {
+			setSubmitError(null);
+			mutation.reset();
+		}
+		wasOpenRef.current = open;
+	}, [mutation.reset, open]);
+	useEffect(() => {
+		if (mutation.isStaleStateSynchronized) {
+			mutation.resetStaleStateError();
+			setSubmitError(null);
+		}
+	}, [mutation.isStaleStateSynchronized, mutation.resetStaleStateError]);
+
+	const requestClose = () => {
+		if (blocksClose) return;
+		onOpenChange(false);
+		setSubmitError(null);
+		mutation.reset();
+	};
+	const archive = async () => {
+		if (blocksClose) return;
+		setSubmitError(null);
+		submitInFlight.current = true;
+		try {
+			// 既アーカイブで返る冪等な 200 も通常の成功として閉じる。
+			await mutation.mutateAsync();
+			if (mountedRef.current) {
+				onOpenChange(false);
+				mutation.reset();
+			}
+		} catch (error) {
+			if (mountedRef.current)
+				setSubmitError(getArchiveHabitErrorMessage(error));
+		} finally {
+			submitInFlight.current = false;
+		}
+	};
+
+	return (
+		<Dialog.Root
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) requestClose();
+			}}
+		>
+			<Dialog.Portal>
+				<Dialog.Overlay className="fixed inset-0 bg-stone-950/30" />
+				<Dialog.Content
+					aria-busy={blocksClose || undefined}
+					className="fixed top-1/2 left-1/2 max-h-[calc(100vh-2rem)] w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-xl border border-stone-200 bg-white p-6 shadow-xl focus:outline-none"
+					onCloseAutoFocus={(event) => {
+						event.preventDefault();
+						triggerRef.current?.focus();
+					}}
+					onEscapeKeyDown={(event) => {
+						if (blocksClose) event.preventDefault();
+					}}
+					onInteractOutside={(event) => {
+						if (blocksClose) event.preventDefault();
+					}}
+				>
+					<Dialog.Title className="text-lg font-semibold text-stone-950">
+						「{habit.name}」をアーカイブしますか？
+					</Dialog.Title>
+					<Dialog.Description className="mt-3 space-y-1 text-sm text-stone-600">
+						<span className="block">
+							アーカイブした習慣は今日の習慣に表示されなくなります。
+						</span>
+						<span className="block">
+							アーカイブ済み習慣の復元 UI はありません。
+						</span>
+					</Dialog.Description>
+					{submitError ? (
+						<p className="mt-4 text-sm text-red-700" role="alert">
+							{submitError}
+						</p>
+					) : null}
+					<div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+						<button
+							className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-stone-300 bg-white px-4 py-2.5 text-sm font-semibold text-stone-800 shadow-sm transition hover:bg-stone-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-stone-100 disabled:text-stone-500"
+							disabled={blocksClose}
+							onClick={requestClose}
+							type="button"
+						>
+							キャンセル
+						</button>
+						<button
+							aria-busy={blocksClose || undefined}
+							className="inline-flex cursor-pointer items-center justify-center rounded-lg bg-red-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-700 disabled:cursor-not-allowed disabled:bg-red-100 disabled:text-red-900"
+							disabled={blocksClose}
+							onClick={archive}
+							type="button"
+						>
+							{mutation.isPending
+								? "アーカイブしています…"
+								: isHabitSynchronizing
+									? "状態を確認しています…"
+									: "アーカイブする"}
+						</button>
+					</div>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/web-app/src/features/habits/archive-confirm-dialog.tsx
+++ b/web-app/src/features/habits/archive-confirm-dialog.tsx
@@ -31,8 +31,9 @@ export function ArchiveConfirmDialog({
 	const isAnyHabitMutationPending = useIsHabitMutationPending(habit.id);
 	const isHabitSynchronizing = useIsHabitMutationSynchronizing(habit.id);
 	const isPending = mutation.isPending || isAnyHabitMutationPending;
-	const blocksClose =
+	const shouldBlockInteraction = () =>
 		isPending || isHabitSynchronizing || submitInFlight.current;
+	const blocksClose = shouldBlockInteraction();
 
 	useEffect(() => {
 		mountedRef.current = true;
@@ -55,13 +56,13 @@ export function ArchiveConfirmDialog({
 	}, [mutation.isStaleStateSynchronized, mutation.resetStaleStateError]);
 
 	const requestClose = () => {
-		if (blocksClose) return;
+		if (shouldBlockInteraction()) return;
 		onOpenChange(false);
 		setSubmitError(null);
 		mutation.reset();
 	};
 	const archive = async () => {
-		if (blocksClose) return;
+		if (shouldBlockInteraction()) return;
 		setSubmitError(null);
 		submitInFlight.current = true;
 		try {
@@ -96,10 +97,10 @@ export function ArchiveConfirmDialog({
 						triggerRef.current?.focus();
 					}}
 					onEscapeKeyDown={(event) => {
-						if (blocksClose) event.preventDefault();
+						if (shouldBlockInteraction()) event.preventDefault();
 					}}
 					onInteractOutside={(event) => {
-						if (blocksClose) event.preventDefault();
+						if (shouldBlockInteraction()) event.preventDefault();
 					}}
 				>
 					<Dialog.Title className="text-lg font-semibold text-stone-950">

--- a/web-app/src/features/habits/complete-button.tsx
+++ b/web-app/src/features/habits/complete-button.tsx
@@ -4,6 +4,7 @@ import { ApiClientError } from "~/lib/api/client";
 import {
 	useCompleteHabitMutation,
 	useIsHabitMutationPending,
+	useIsHabitMutationSynchronizing,
 } from "./habits.mutations";
 
 type CompleteButtonProps = {
@@ -40,6 +41,7 @@ export function getCompleteHabitErrorMessage(error: unknown): string | null {
 export function CompleteButton({ habit, onUnauthorized }: CompleteButtonProps) {
 	const mutation = useCompleteHabitMutation(habit.id, { onUnauthorized });
 	const isHabitMutationPending = useIsHabitMutationPending(habit.id);
+	const isSharedHabitSynchronizing = useIsHabitMutationSynchronizing(habit.id);
 	const submitInFlight = useRef(false);
 	const errorMessage = getCompleteHabitErrorMessage(mutation.error);
 	const {
@@ -47,6 +49,8 @@ export function CompleteButton({ habit, onUnauthorized }: CompleteButtonProps) {
 		isStaleStateSynchronizing,
 		resetStaleStateError,
 	} = mutation;
+	const isHabitSynchronizing =
+		isStaleStateSynchronizing || isSharedHabitSynchronizing;
 
 	useEffect(() => {
 		if (isStaleStateSynchronized) {
@@ -58,7 +62,7 @@ export function CompleteButton({ habit, onUnauthorized }: CompleteButtonProps) {
 		if (
 			habit.isCompletedToday ||
 			isHabitMutationPending ||
-			isStaleStateSynchronizing ||
+			isHabitSynchronizing ||
 			submitInFlight.current
 		) {
 			return;
@@ -74,25 +78,23 @@ export function CompleteButton({ habit, onUnauthorized }: CompleteButtonProps) {
 
 	const isCompleting = mutation.isPending;
 	const isDisabled =
-		habit.isCompletedToday ||
-		isHabitMutationPending ||
-		isStaleStateSynchronizing;
+		habit.isCompletedToday || isHabitMutationPending || isHabitSynchronizing;
 	const label = habit.isCompletedToday
 		? "✓ 達成済み"
 		: isCompleting
 			? "達成しています…"
-			: isStaleStateSynchronizing
+			: isHabitSynchronizing
 				? "状態を確認しています…"
 				: "達成する";
 
 	return (
 		<div className="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:items-end">
 			<button
-				aria-busy={isCompleting || isStaleStateSynchronizing || undefined}
+				aria-busy={isCompleting || isHabitSynchronizing || undefined}
 				aria-label={`${habit.name}を${
 					isCompleting
 						? "達成しています"
-						: isStaleStateSynchronizing
+						: isHabitSynchronizing
 							? "最新状態を確認しています"
 							: habit.isCompletedToday
 								? "達成済み"

--- a/web-app/src/features/habits/edit-habit-dialog.tsx
+++ b/web-app/src/features/habits/edit-habit-dialog.tsx
@@ -48,6 +48,7 @@ export function EditHabitDialog({
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const wasOpenRef = useRef(false);
 	const submitInFlight = useRef(false);
+	const refetchHomeAfterClose = useRef(false);
 	const nameInputRef = useRef<HTMLInputElement>(null);
 	const mountedRef = useRef(true);
 	const mutation = useUpdateHabitMutation(habit.id, { onUnauthorized });
@@ -117,6 +118,7 @@ export function EditHabitDialog({
 				emoji: validEmoji.value,
 			});
 			if (mountedRef.current) {
+				refetchHomeAfterClose.current = true;
 				onOpenChange(false);
 				resetToLatestValues();
 			}
@@ -144,6 +146,10 @@ export function EditHabitDialog({
 					onCloseAutoFocus={(event) => {
 						event.preventDefault();
 						triggerRef.current?.focus();
+						if (refetchHomeAfterClose.current) {
+							refetchHomeAfterClose.current = false;
+							void mutation.refetchHome();
+						}
 					}}
 					onEscapeKeyDown={(event) => {
 						if (blocksClose) event.preventDefault();

--- a/web-app/src/features/habits/edit-habit-dialog.tsx
+++ b/web-app/src/features/habits/edit-habit-dialog.tsx
@@ -1,0 +1,274 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { useEffect, useRef, useState } from "react";
+import type { HomeHabit } from "~/features/home/home.contract";
+import { getEditHabitErrorMessage } from "./habit-dialog-errors";
+import { validateHabitEmoji, validateHabitName } from "./habit-validation";
+import {
+	useIsHabitMutationPending,
+	useIsHabitMutationSynchronizing,
+	useUpdateHabitMutation,
+} from "./habits.mutations";
+
+type FieldErrors = { name?: string; emoji?: string };
+
+type EditHabitDialogProps = {
+	habit: HomeHabit;
+	open: boolean;
+	triggerRef: React.RefObject<HTMLButtonElement | null>;
+	onOpenChange: (open: boolean) => void;
+	onUnauthorized?: () => void | Promise<void>;
+};
+
+function getNameError(value: string): string | undefined {
+	const result = validateHabitName(value);
+	if (result.isValid) return undefined;
+	return result.reason === "required"
+		? "習慣名を入力してください"
+		: "習慣名は50文字以内で入力してください";
+}
+
+function getEmojiError(value: string): string | undefined {
+	const result = validateHabitEmoji(value);
+	if (result.isValid) return undefined;
+	return result.reason === "multiple"
+		? "絵文字は1つだけ入力してください"
+		: "絵文字を1つだけ入力してください";
+}
+
+export function EditHabitDialog({
+	habit,
+	open,
+	triggerRef,
+	onOpenChange,
+	onUnauthorized,
+}: EditHabitDialogProps) {
+	const [name, setName] = useState(habit.name);
+	const [emoji, setEmoji] = useState(habit.emoji);
+	const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+	const [submitError, setSubmitError] = useState<string | null>(null);
+	const wasOpenRef = useRef(false);
+	const submitInFlight = useRef(false);
+	const nameInputRef = useRef<HTMLInputElement>(null);
+	const mountedRef = useRef(true);
+	const mutation = useUpdateHabitMutation(habit.id, { onUnauthorized });
+	const isAnyHabitMutationPending = useIsHabitMutationPending(habit.id);
+	const isHabitSynchronizing = useIsHabitMutationSynchronizing(habit.id);
+	const isPending = mutation.isPending || isAnyHabitMutationPending;
+
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (open && !wasOpenRef.current) {
+			setName(habit.name);
+			setEmoji(habit.emoji);
+			setFieldErrors({});
+			setSubmitError(null);
+			mutation.reset();
+		}
+		wasOpenRef.current = open;
+	}, [habit.emoji, habit.name, mutation.reset, open]);
+
+	useEffect(() => {
+		if (mutation.isStaleStateSynchronized) {
+			mutation.resetStaleStateError();
+			setSubmitError(null);
+		}
+	}, [mutation.isStaleStateSynchronized, mutation.resetStaleStateError]);
+
+	const resetToLatestValues = () => {
+		setName(habit.name);
+		setEmoji(habit.emoji);
+		setFieldErrors({});
+		setSubmitError(null);
+		mutation.reset();
+	};
+	const requestClose = () => {
+		if (isPending || isHabitSynchronizing || submitInFlight.current) return;
+		onOpenChange(false);
+		resetToLatestValues();
+	};
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (isPending || isHabitSynchronizing || submitInFlight.current) return;
+
+		const nameError = getNameError(name);
+		const emojiError = getEmojiError(emoji);
+		if (nameError || emojiError) {
+			setFieldErrors({ name: nameError, emoji: emojiError });
+			setSubmitError(null);
+			return;
+		}
+		const validName = validateHabitName(name);
+		const validEmoji = validateHabitEmoji(emoji);
+		if (!validName.isValid || !validEmoji.isValid) return;
+
+		setFieldErrors({});
+		setSubmitError(null);
+		submitInFlight.current = true;
+		try {
+			// name / emoji を常に送るため、絵文字を空文字にして未設定へ戻せる。
+			await mutation.mutateAsync({
+				name: validName.value,
+				emoji: validEmoji.value,
+			});
+			if (mountedRef.current) {
+				onOpenChange(false);
+				resetToLatestValues();
+			}
+		} catch (error) {
+			if (mountedRef.current) setSubmitError(getEditHabitErrorMessage(error));
+		} finally {
+			submitInFlight.current = false;
+		}
+	};
+
+	const blocksClose =
+		isPending || isHabitSynchronizing || submitInFlight.current;
+	return (
+		<Dialog.Root
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) requestClose();
+			}}
+		>
+			<Dialog.Portal>
+				<Dialog.Overlay className="fixed inset-0 bg-stone-950/30" />
+				<Dialog.Content
+					aria-busy={blocksClose || undefined}
+					className="fixed top-1/2 left-1/2 max-h-[calc(100vh-2rem)] w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-xl border border-stone-200 bg-white p-6 shadow-xl focus:outline-none"
+					onCloseAutoFocus={(event) => {
+						event.preventDefault();
+						triggerRef.current?.focus();
+					}}
+					onEscapeKeyDown={(event) => {
+						if (blocksClose) event.preventDefault();
+					}}
+					onInteractOutside={(event) => {
+						if (blocksClose) event.preventDefault();
+					}}
+					onOpenAutoFocus={(event) => {
+						event.preventDefault();
+						nameInputRef.current?.focus();
+					}}
+				>
+					<Dialog.Title className="text-lg font-semibold text-stone-950">
+						習慣を編集
+					</Dialog.Title>
+					<Dialog.Description className="mt-1 text-sm text-stone-600">
+						習慣名と絵文字を変更できます。
+					</Dialog.Description>
+					<form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+						<div>
+							<label
+								className="block text-sm font-medium text-stone-900"
+								htmlFor={`edit-habit-name-${habit.id}`}
+							>
+								習慣名
+							</label>
+							<input
+								aria-describedby={
+									fieldErrors.name
+										? `edit-habit-name-error-${habit.id}`
+										: undefined
+								}
+								aria-invalid={fieldErrors.name ? true : undefined}
+								className="mt-1 w-full rounded-lg border border-stone-300 bg-white px-3 py-2 text-stone-950 shadow-sm outline-none placeholder:text-stone-400 focus:border-emerald-700 focus:ring-2 focus:ring-emerald-100 disabled:cursor-not-allowed disabled:bg-stone-100"
+								disabled={blocksClose}
+								id={`edit-habit-name-${habit.id}`}
+								onChange={(event) => {
+									setName(event.target.value);
+									setFieldErrors((current) => ({
+										...current,
+										name: undefined,
+									}));
+									setSubmitError(null);
+								}}
+								ref={nameInputRef}
+								value={name}
+							/>
+							{fieldErrors.name ? (
+								<p
+									className="mt-1 text-sm text-red-700"
+									id={`edit-habit-name-error-${habit.id}`}
+									role="alert"
+								>
+									{fieldErrors.name}
+								</p>
+							) : null}
+						</div>
+						<div>
+							<label
+								className="block text-sm font-medium text-stone-900"
+								htmlFor={`edit-habit-emoji-${habit.id}`}
+							>
+								絵文字（任意）
+							</label>
+							<input
+								aria-describedby={
+									fieldErrors.emoji
+										? `edit-habit-emoji-error-${habit.id}`
+										: undefined
+								}
+								aria-invalid={fieldErrors.emoji ? true : undefined}
+								className="mt-1 w-full rounded-lg border border-stone-300 bg-white px-3 py-2 text-stone-950 shadow-sm outline-none placeholder:text-stone-400 focus:border-emerald-700 focus:ring-2 focus:ring-emerald-100 disabled:cursor-not-allowed disabled:bg-stone-100"
+								disabled={blocksClose}
+								id={`edit-habit-emoji-${habit.id}`}
+								onChange={(event) => {
+									setEmoji(event.target.value);
+									setFieldErrors((current) => ({
+										...current,
+										emoji: undefined,
+									}));
+									setSubmitError(null);
+								}}
+								placeholder="例: 📚"
+								value={emoji}
+							/>
+							{fieldErrors.emoji ? (
+								<p
+									className="mt-1 text-sm text-red-700"
+									id={`edit-habit-emoji-error-${habit.id}`}
+									role="alert"
+								>
+									{fieldErrors.emoji}
+								</p>
+							) : null}
+						</div>
+						{submitError ? (
+							<p className="text-sm text-red-700" role="alert">
+								{submitError}
+							</p>
+						) : null}
+						<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+							<button
+								className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-stone-300 bg-white px-4 py-2.5 text-sm font-semibold text-stone-800 shadow-sm transition hover:bg-stone-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-stone-100 disabled:text-stone-500"
+								disabled={blocksClose}
+								onClick={requestClose}
+								type="button"
+							>
+								キャンセル
+							</button>
+							<button
+								aria-busy={blocksClose || undefined}
+								className="inline-flex cursor-pointer items-center justify-center rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-100 disabled:text-emerald-900"
+								disabled={blocksClose}
+								type="submit"
+							>
+								{mutation.isPending
+									? "保存しています…"
+									: isHabitSynchronizing
+										? "状態を確認しています…"
+										: "保存"}
+							</button>
+						</div>
+					</form>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/web-app/src/features/habits/habit-action-menu.test.tsx
+++ b/web-app/src/features/habits/habit-action-menu.test.tsx
@@ -181,6 +181,43 @@ describe("HabitActionMenu", () => {
 		);
 	});
 
+	it("アーカイブ後のrefetch中に別controlへ移したfocusを完了時に奪わない", async () => {
+		const user = userEvent.setup();
+		const refetch = deferred<Response>();
+		const walk = makeHabit({ id: "walk", name: "散歩", emoji: "🚶" });
+		let homeCalls = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeCalls += 1;
+					return homeCalls === 1
+						? Promise.resolve(jsonResponse(homeData([makeHabit(), walk])))
+						: refetch.promise;
+				}
+				return Promise.resolve(jsonResponse(habitResponse()));
+			}),
+		);
+		const client = createQueryClient();
+		render(<ActiveHomeHabitList />, { wrapper: wrapper(client) });
+		await screen.findByRole("button", { name: "読書 の操作メニュー" });
+		await openMenuItem(user, "アーカイブ");
+		await user.click(screen.getByRole("button", { name: "アーカイブする" }));
+		await vi.waitFor(() => expect(homeCalls).toBe(2));
+		const nextControl = screen.getByRole("button", { name: "散歩を達成する" });
+		nextControl.focus();
+		expect(nextControl).toHaveFocus();
+
+		refetch.resolve(jsonResponse(homeData([walk])));
+		await vi.waitFor(() =>
+			expect(
+				screen.queryByRole("button", { name: "読書を達成する" }),
+			).not.toBeInTheDocument(),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(nextControl).toHaveFocus();
+	});
+
 	it.each([
 		["編集", "HABIT_ARCHIVED", 409, "この習慣はすでにアーカイブされています"],
 		["編集", "HABIT_NOT_FOUND", 404, "習慣が見つかりません"],

--- a/web-app/src/features/habits/habit-action-menu.test.tsx
+++ b/web-app/src/features/habits/habit-action-menu.test.tsx
@@ -1,0 +1,442 @@
+import {
+	QueryClient,
+	QueryClientProvider,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HomeHabit } from "~/features/home/home.contract";
+import { homeQueryOptions } from "~/features/home/home.query";
+import { HabitActionMenu } from "./habit-action-menu";
+import { HabitList } from "./habit-list";
+import { habitMutationKey } from "./habits.mutations";
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("HabitActionMenu", () => {
+	it("habit名を含むmenuをmouseとkeyboardで操作し、編集Dialogへfocusを移す", async () => {
+		const user = userEvent.setup();
+		renderWithClient(<HabitActionMenu habit={makeHabit()} />);
+		const trigger = screen.getByRole("button", { name: "読書 の操作メニュー" });
+		await user.click(trigger);
+		expect(screen.getByRole("menuitem", { name: "編集" })).toBeInTheDocument();
+		expect(
+			screen.getByRole("menuitem", { name: "アーカイブ" }),
+		).toBeInTheDocument();
+
+		await user.keyboard("{ArrowDown}{Enter}");
+		expect(
+			screen.getByRole("dialog", { name: "習慣を編集" }),
+		).toBeInTheDocument();
+		expect(screen.getByLabelText("習慣名")).toHaveFocus();
+		expect(screen.getByLabelText("習慣名")).toHaveValue("読書");
+		expect(screen.getByLabelText("絵文字（任意）")).toHaveValue("📚");
+		await user.keyboard("{Escape}");
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		expect(trigger).toHaveFocus();
+	});
+
+	it("編集ではshared validationを使い、emojiの空文字を含む両fieldのPATCH payloadを送る", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValue(jsonResponse(habitResponse({ emoji: "" }))),
+		);
+		renderWithClient(<HabitActionMenu habit={makeHabit()} />);
+		await openMenuItem(user, "編集");
+		const name = screen.getByLabelText("習慣名");
+		await user.clear(name);
+		await user.click(screen.getByRole("button", { name: "保存" }));
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"習慣名を入力してください",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+		await user.type(name, "  毎日読む  ");
+		await user.clear(screen.getByLabelText("絵文字（任意）"));
+		await user.click(screen.getByRole("button", { name: "保存" }));
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/habits/reading",
+			expect.objectContaining({
+				method: "PATCH",
+				body: JSON.stringify({ name: "毎日読む", emoji: "" }),
+			}),
+		);
+	});
+
+	it("no-op updateも成功として扱い、active home refetch完了まで編集Dialogを閉じない", async () => {
+		const user = userEvent.setup();
+		const refetch = deferred<Response>();
+		let homeCalls = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeCalls += 1;
+					return homeCalls === 1
+						? Promise.resolve(jsonResponse(homeData()))
+						: refetch.promise;
+				}
+				return Promise.resolve(jsonResponse(habitResponse()));
+			}),
+		);
+		const client = createQueryClient();
+		render(<ActiveHomeMenu />, { wrapper: wrapper(client) });
+		await screen.findByRole("button", { name: "読書 の操作メニュー" });
+		await openMenuItem(user, "編集");
+		await user.click(screen.getByRole("button", { name: "保存" }));
+		await vi.waitFor(() => expect(homeCalls).toBe(2));
+		expect(
+			screen.getByRole("button", { name: "保存しています…" }),
+		).toBeDisabled();
+		refetch.resolve(jsonResponse(homeData()));
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/habits/reading",
+			expect.objectContaining({
+				body: JSON.stringify({ name: "読書", emoji: "📚" }),
+			}),
+		);
+	});
+
+	it("アーカイブ確認の正確な文言・idempotent 200・pathを扱う", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValue(
+				jsonResponse(
+					habitResponse({ archivedAt: "2026-08-08T00:00:00+09:00" }),
+				),
+			),
+		);
+		renderWithClient(<HabitActionMenu habit={makeHabit()} />);
+		await openMenuItem(user, "アーカイブ");
+		expect(
+			screen.getByRole("dialog", { name: "「読書」をアーカイブしますか？" }),
+		).toHaveTextContent(
+			"アーカイブした習慣は今日の習慣に表示されなくなります。",
+		);
+		expect(screen.getByRole("dialog")).toHaveTextContent(
+			"アーカイブ済み習慣の復元 UI はありません。",
+		);
+		expect(screen.getByRole("dialog")).not.toHaveTextContent("削除");
+		await user.click(screen.getByRole("button", { name: "アーカイブする" }));
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/habits/reading/archive",
+			expect.objectContaining({ method: "PATCH" }),
+		);
+	});
+
+	it.each([
+		["編集", "HABIT_ARCHIVED", 409, "この習慣はすでにアーカイブされています"],
+		["編集", "HABIT_NOT_FOUND", 404, "習慣が見つかりません"],
+		["アーカイブ", "HABIT_NOT_FOUND", 404, "習慣が見つかりません"],
+		[
+			"アーカイブ",
+			"INTERNAL_SERVER_ERROR",
+			500,
+			"処理に失敗しました。時間をおいて再試行してください",
+		],
+	] as const)(
+		"%s の %s をDialog内に表示して値を維持する",
+		async (action, code, status, message) => {
+			const user = userEvent.setup();
+			vi.stubGlobal(
+				"fetch",
+				fetchMock.mockResolvedValue(
+					jsonResponse({ code, message: "API message" }, status),
+				),
+			);
+			renderWithClient(<HabitActionMenu habit={makeHabit()} />);
+			await openMenuItem(user, action);
+			if (action === "編集") {
+				await user.clear(screen.getByLabelText("習慣名"));
+				await user.type(screen.getByLabelText("習慣名"), "変更後");
+				await user.click(screen.getByRole("button", { name: "保存" }));
+				expect(await screen.findByRole("alert")).toHaveTextContent(message);
+				expect(screen.getByLabelText("習慣名")).toHaveValue("変更後");
+			} else {
+				await user.click(
+					screen.getByRole("button", { name: "アーカイブする" }),
+				);
+				expect(await screen.findByRole("alert")).toHaveTextContent(message);
+			}
+			expect(screen.getByRole("dialog")).toBeInTheDocument();
+		},
+	);
+
+	it("401はDialog内alertを出さずglobal auth handlingへ委譲する", async () => {
+		const user = userEvent.setup();
+		const onUnauthorized = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockResolvedValue(
+				jsonResponse(
+					{ code: "UNAUTHORIZED", message: "ログインが必要です。" },
+					401,
+				),
+			),
+		);
+		renderWithClient(
+			<HabitActionMenu habit={makeHabit()} onUnauthorized={onUnauthorized} />,
+		);
+		await openMenuItem(user, "編集");
+		await user.click(screen.getByRole("button", { name: "保存" }));
+		await vi.waitFor(() => expect(onUnauthorized).toHaveBeenCalledTimes(1));
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it.each([
+		[
+			"編集",
+			"/api/habits/reading",
+			"保存",
+			"HABIT_ARCHIVED",
+			409,
+			"この習慣はすでにアーカイブされています",
+		],
+		[
+			"アーカイブ",
+			"/api/habits/reading/archive",
+			"アーカイブする",
+			"HABIT_NOT_FOUND",
+			404,
+			"習慣が見つかりません",
+		],
+	] as const)(
+		"%s のstale-state errorは再同期成功まで表示し、成功後にDialog内から消える",
+		async (action, path, submitLabel, code, status, message) => {
+			const user = userEvent.setup();
+			const refetch = deferred<Response>();
+			let homeCalls = 0;
+			vi.stubGlobal(
+				"fetch",
+				fetchMock.mockImplementation((requestPath: string) => {
+					if (requestPath === "/api/home") {
+						homeCalls += 1;
+						return homeCalls === 1
+							? Promise.resolve(jsonResponse(homeData()))
+							: refetch.promise;
+					}
+					expect(requestPath).toBe(path);
+					return Promise.resolve(
+						jsonResponse({ code, message: "API message" }, status),
+					);
+				}),
+			);
+			const client = createQueryClient();
+			render(<ActiveHomeMenu />, { wrapper: wrapper(client) });
+			await screen.findByRole("button", { name: "読書 の操作メニュー" });
+			await openMenuItem(user, action);
+			await user.click(screen.getByRole("button", { name: submitLabel }));
+			expect(await screen.findByRole("alert")).toHaveTextContent(message);
+			await vi.waitFor(() => expect(homeCalls).toBe(2));
+			expect(
+				screen.getByRole("button", { name: "状態を確認しています…" }),
+			).toBeDisabled();
+			refetch.resolve(jsonResponse(homeData()));
+			await vi.waitFor(() =>
+				expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+			);
+			expect(screen.getByRole("dialog")).toBeInTheDocument();
+		},
+	);
+
+	it("pending中は同じhabitのmenuとDialog close・二重送信を抑止し、別habitは操作できる", async () => {
+		const user = userEvent.setup();
+		const archive = deferred<Response>();
+		vi.stubGlobal("fetch", fetchMock.mockReturnValue(archive.promise));
+		renderWithClient(
+			<>
+				<HabitActionMenu habit={makeHabit()} />
+				<HabitActionMenu habit={makeHabit({ id: "walk", name: "散歩" })} />
+			</>,
+		);
+		await openMenuItem(user, "アーカイブ");
+		const submit = screen.getByRole("button", { name: "アーカイブする" });
+		await user.dblClick(submit);
+		await vi.waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: "アーカイブしています…" }),
+			).toBeDisabled(),
+		);
+		expect(
+			screen.getByRole("button", { name: "読書 の操作メニュー", hidden: true }),
+		).toBeDisabled();
+		expect(
+			screen.getByRole("button", { name: "散歩 の操作メニュー", hidden: true }),
+		).toBeEnabled();
+		await user.keyboard("{Escape}");
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(
+			fetchMock.mock.calls.filter(
+				([path]) => path === "/api/habits/reading/archive",
+			),
+		).toHaveLength(1);
+		await act(async () => archive.resolve(jsonResponse(habitResponse())));
+	});
+
+	it("同一habitの既存mutation中はmenuを無効化する", async () => {
+		const pending = deferred<void>();
+		const client = createQueryClient();
+		const mutation = client.getMutationCache().build(client, {
+			mutationKey: habitMutationKey("reading", "complete"),
+			mutationFn: () => pending.promise,
+		});
+		const execution = mutation.execute(undefined);
+		render(<HabitActionMenu habit={makeHabit()} />, {
+			wrapper: wrapper(client),
+		});
+		await vi.waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: "読書 の操作メニュー" }),
+			).toBeDisabled(),
+		);
+		pending.resolve();
+		await execution;
+	});
+
+	it("updateのstale再同期中はCompleteButtonが共有状態を見てPOSTを開始しない", async () => {
+		const user = userEvent.setup();
+		const refetch = deferred<Response>();
+		let homeCalls = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeCalls += 1;
+					return homeCalls === 1
+						? Promise.resolve(jsonResponse(homeData()))
+						: refetch.promise;
+				}
+				if (path === "/api/habits/reading") {
+					return Promise.resolve(
+						jsonResponse(
+							{ code: "HABIT_ARCHIVED", message: "API message" },
+							409,
+						),
+					);
+				}
+				return Promise.resolve(jsonResponse({}));
+			}),
+		);
+		const client = createQueryClient();
+		render(<ActiveHomeHabitList />, { wrapper: wrapper(client) });
+		await screen.findByRole("button", { name: "読書 の操作メニュー" });
+		await openMenuItem(user, "編集");
+		await user.click(screen.getByRole("button", { name: "保存" }));
+		await vi.waitFor(() => expect(homeCalls).toBe(2));
+		const complete = screen.getByRole("button", {
+			name: "読書を最新状態を確認しています",
+			hidden: true,
+		});
+		expect(complete).toBeDisabled();
+		expect(complete).toHaveAttribute("aria-busy", "true");
+		complete.click();
+		expect(
+			fetchMock.mock.calls.filter(
+				([path]) => path === "/api/habits/reading/complete",
+			),
+		).toHaveLength(0);
+		refetch.resolve(jsonResponse(homeData()));
+	});
+});
+
+function ActiveHomeMenu() {
+	const client = useQueryClient();
+	const home = useQuery(homeQueryOptions({ enabled: true }, client));
+	return home.data ? (
+		<HabitActionMenu habit={home.data.habits[0]} />
+	) : (
+		<p>読み込み中…</p>
+	);
+}
+
+function ActiveHomeHabitList() {
+	const client = useQueryClient();
+	const home = useQuery(homeQueryOptions({ enabled: true }, client));
+	return home.data ? (
+		<HabitList habits={home.data.habits} />
+	) : (
+		<p>読み込み中…</p>
+	);
+}
+
+function renderWithClient(ui: React.ReactElement) {
+	return render(ui, { wrapper: wrapper(createQueryClient()) });
+}
+function wrapper(queryClient: QueryClient) {
+	return function QueryWrapper({ children }: PropsWithChildren) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+}
+function createQueryClient() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+function makeHabit(overrides: Partial<HomeHabit> = {}): HomeHabit {
+	return {
+		id: "reading",
+		name: "読書",
+		emoji: "📚",
+		currentStreak: 3,
+		maxStreak: 14,
+		isCompletedToday: false,
+		...overrides,
+	};
+}
+function habitResponse(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "reading",
+		name: "読書",
+		emoji: "📚",
+		currentStreak: 3,
+		maxStreak: 14,
+		createdAt: "2026-08-08T00:00:00+09:00",
+		archivedAt: null,
+		...overrides,
+	};
+}
+function homeData() {
+	return {
+		habits: [makeHabit()],
+		activityLog: [{ date: "2026-08-08", completionRate: null }],
+	};
+}
+function jsonResponse(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+async function openMenuItem(
+	user: ReturnType<typeof userEvent.setup>,
+	name: "編集" | "アーカイブ",
+) {
+	await user.click(screen.getByRole("button", { name: "読書 の操作メニュー" }));
+	await user.click(screen.getByRole("menuitem", { name }));
+}

--- a/web-app/src/features/habits/habit-action-menu.test.tsx
+++ b/web-app/src/features/habits/habit-action-menu.test.tsx
@@ -284,11 +284,45 @@ describe("HabitActionMenu", () => {
 		).toBeEnabled();
 		await user.keyboard("{Escape}");
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
-		expect(
-			fetchMock.mock.calls.filter(
-				([path]) => path === "/api/habits/reading/archive",
-			),
-		).toHaveLength(1);
+		await vi.waitFor(() =>
+			expect(
+				fetchMock.mock.calls.filter(
+					([path]) => path === "/api/habits/reading/archive",
+				),
+			).toHaveLength(1),
+		);
+		await act(async () => archive.resolve(jsonResponse(habitResponse())));
+	});
+
+	it("アーカイブ送信と同一turnの二重click・Escapeでも1回だけ送信しDialogを閉じない", async () => {
+		const user = userEvent.setup();
+		const archive = deferred<Response>();
+		vi.stubGlobal("fetch", fetchMock.mockReturnValue(archive.promise));
+		renderWithClient(<HabitActionMenu habit={makeHabit()} />);
+		await openMenuItem(user, "アーカイブ");
+		const submit = screen.getByRole("button", { name: "アーカイブする" });
+
+		act(() => {
+			submit.click();
+			submit.click();
+			document.dispatchEvent(
+				new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+			);
+		});
+
+		await vi.waitFor(() =>
+			expect(
+				fetchMock.mock.calls.filter(
+					([path]) => path === "/api/habits/reading/archive",
+				),
+			).toHaveLength(1),
+		);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		await vi.waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: "アーカイブしています…" }),
+			).toBeDisabled(),
+		);
 		await act(async () => archive.resolve(jsonResponse(habitResponse())));
 	});
 

--- a/web-app/src/features/habits/habit-action-menu.test.tsx
+++ b/web-app/src/features/habits/habit-action-menu.test.tsx
@@ -75,7 +75,7 @@ describe("HabitActionMenu", () => {
 		);
 	});
 
-	it("no-op updateも成功として扱い、active home refetch完了まで編集Dialogを閉じない", async () => {
+	it("no-op updateも成功として扱い、Dialog closeとfocus復帰後にactive homeをrefetchする", async () => {
 		const user = userEvent.setup();
 		const refetch = deferred<Response>();
 		let homeCalls = 0;
@@ -95,15 +95,17 @@ describe("HabitActionMenu", () => {
 		render(<ActiveHomeMenu />, { wrapper: wrapper(client) });
 		await screen.findByRole("button", { name: "読書 の操作メニュー" });
 		await openMenuItem(user, "編集");
+		const trigger = screen.getByRole("button", {
+			name: "読書 の操作メニュー",
+			hidden: true,
+		});
 		await user.click(screen.getByRole("button", { name: "保存" }));
-		await vi.waitFor(() => expect(homeCalls).toBe(2));
-		expect(
-			screen.getByRole("button", { name: "保存しています…" }),
-		).toBeDisabled();
-		refetch.resolve(jsonResponse(homeData()));
 		await vi.waitFor(() =>
 			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
 		);
+		expect(trigger).toHaveFocus();
+		await vi.waitFor(() => expect(homeCalls).toBe(2));
+		refetch.resolve(jsonResponse(homeData()));
 		expect(fetchMock).toHaveBeenCalledWith(
 			"/api/habits/reading",
 			expect.objectContaining({
@@ -140,6 +142,42 @@ describe("HabitActionMenu", () => {
 		expect(fetchMock).toHaveBeenCalledWith(
 			"/api/habits/reading/archive",
 			expect.objectContaining({ method: "PATCH" }),
+		);
+	});
+
+	it("アーカイブ成功はcloseとtrigger focus後にrefetchし、card消滅後は一覧へfocusを移す", async () => {
+		const user = userEvent.setup();
+		const refetch = deferred<Response>();
+		let homeCalls = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeCalls += 1;
+					return homeCalls === 1
+						? Promise.resolve(jsonResponse(homeData()))
+						: refetch.promise;
+				}
+				return Promise.resolve(jsonResponse(habitResponse()));
+			}),
+		);
+		const client = createQueryClient();
+		render(<ActiveHomeHabitList />, { wrapper: wrapper(client) });
+		const trigger = await screen.findByRole("button", {
+			name: "読書 の操作メニュー",
+		});
+		await openMenuItem(user, "アーカイブ");
+		await user.click(screen.getByRole("button", { name: "アーカイブする" }));
+
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+		);
+		expect(trigger).toHaveFocus();
+		await vi.waitFor(() => expect(homeCalls).toBe(2));
+		refetch.resolve(jsonResponse(homeData([])));
+		await screen.findByText("今日の習慣はまだありません。");
+		await vi.waitFor(() =>
+			expect(screen.getByRole("region", { name: "今日の習慣" })).toHaveFocus(),
 		);
 	});
 
@@ -448,9 +486,9 @@ function habitResponse(overrides: Record<string, unknown> = {}) {
 		...overrides,
 	};
 }
-function homeData() {
+function homeData(habits: HomeHabit[] = [makeHabit()]) {
 	return {
-		habits: [makeHabit()],
+		habits,
 		activityLog: [{ date: "2026-08-08", completionRate: null }],
 	};
 }

--- a/web-app/src/features/habits/habit-action-menu.tsx
+++ b/web-app/src/features/habits/habit-action-menu.tsx
@@ -10,11 +10,13 @@ import {
 
 type HabitActionMenuProps = {
 	habit: HomeHabit;
+	archiveFallbackFocusRef?: React.RefObject<HTMLElement | null>;
 	onUnauthorized?: () => void | Promise<void>;
 };
 
 export function HabitActionMenu({
 	habit,
+	archiveFallbackFocusRef,
 	onUnauthorized,
 }: HabitActionMenuProps) {
 	const [editOpen, setEditOpen] = useState(false);
@@ -82,6 +84,7 @@ export function HabitActionMenu({
 				triggerRef={triggerRef}
 			/>
 			<ArchiveConfirmDialog
+				fallbackFocusRef={archiveFallbackFocusRef}
 				habit={habit}
 				onOpenChange={setArchiveOpen}
 				onUnauthorized={onUnauthorized}

--- a/web-app/src/features/habits/habit-action-menu.tsx
+++ b/web-app/src/features/habits/habit-action-menu.tsx
@@ -1,0 +1,93 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { useRef, useState } from "react";
+import type { HomeHabit } from "~/features/home/home.contract";
+import { ArchiveConfirmDialog } from "./archive-confirm-dialog";
+import { EditHabitDialog } from "./edit-habit-dialog";
+import {
+	useIsHabitMutationPending,
+	useIsHabitMutationSynchronizing,
+} from "./habits.mutations";
+
+type HabitActionMenuProps = {
+	habit: HomeHabit;
+	onUnauthorized?: () => void | Promise<void>;
+};
+
+export function HabitActionMenu({
+	habit,
+	onUnauthorized,
+}: HabitActionMenuProps) {
+	const [editOpen, setEditOpen] = useState(false);
+	const [archiveOpen, setArchiveOpen] = useState(false);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const isHabitMutationPending = useIsHabitMutationPending(habit.id);
+	const isHabitSynchronizing = useIsHabitMutationSynchronizing(habit.id);
+	const isDisabled = isHabitMutationPending || isHabitSynchronizing;
+
+	return (
+		<div className="self-start sm:self-auto">
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger asChild>
+					<button
+						aria-busy={isHabitSynchronizing || undefined}
+						aria-label={`${habit.name} の操作メニュー`}
+						className="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border border-stone-300 bg-white text-lg leading-none text-stone-700 shadow-sm transition hover:bg-stone-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-stone-100 disabled:text-stone-400"
+						disabled={isDisabled}
+						ref={triggerRef}
+						type="button"
+					>
+						…
+					</button>
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Portal>
+					<DropdownMenu.Content
+						align="end"
+						className="z-50 min-w-32 rounded-lg border border-stone-200 bg-white p-1 shadow-lg"
+						sideOffset={6}
+					>
+						<DropdownMenu.Item
+							className="cursor-pointer rounded-md px-3 py-2 text-sm text-stone-800 outline-none data-[highlighted]:bg-emerald-50 data-[highlighted]:text-emerald-950 data-[disabled]:cursor-not-allowed data-[disabled]:text-stone-400"
+							disabled={isDisabled}
+							onSelect={(event) => {
+								if (isDisabled) {
+									event.preventDefault();
+									return;
+								}
+								setEditOpen(true);
+							}}
+						>
+							編集
+						</DropdownMenu.Item>
+						<DropdownMenu.Item
+							className="cursor-pointer rounded-md px-3 py-2 text-sm text-red-700 outline-none data-[highlighted]:bg-red-50 data-[highlighted]:text-red-900 data-[disabled]:cursor-not-allowed data-[disabled]:text-stone-400"
+							disabled={isDisabled}
+							onSelect={(event) => {
+								if (isDisabled) {
+									event.preventDefault();
+									return;
+								}
+								setArchiveOpen(true);
+							}}
+						>
+							アーカイブ
+						</DropdownMenu.Item>
+					</DropdownMenu.Content>
+				</DropdownMenu.Portal>
+			</DropdownMenu.Root>
+			<EditHabitDialog
+				habit={habit}
+				onOpenChange={setEditOpen}
+				onUnauthorized={onUnauthorized}
+				open={editOpen}
+				triggerRef={triggerRef}
+			/>
+			<ArchiveConfirmDialog
+				habit={habit}
+				onOpenChange={setArchiveOpen}
+				onUnauthorized={onUnauthorized}
+				open={archiveOpen}
+				triggerRef={triggerRef}
+			/>
+		</div>
+	);
+}

--- a/web-app/src/features/habits/habit-card.tsx
+++ b/web-app/src/features/habits/habit-card.tsx
@@ -1,5 +1,6 @@
 import type { HomeHabit } from "~/features/home/home.contract";
 import { CompleteButton } from "./complete-button";
+import { HabitActionMenu } from "./habit-action-menu";
 
 type HabitCardProps = {
 	habit: HomeHabit;
@@ -28,7 +29,10 @@ export function HabitCard({ habit, onUnauthorized }: HabitCardProps) {
 						現在 {habit.currentStreak}日 ・ 最長 {habit.maxStreak}日
 					</p>
 				</div>
-				<CompleteButton habit={habit} onUnauthorized={onUnauthorized} />
+				<div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-start">
+					<CompleteButton habit={habit} onUnauthorized={onUnauthorized} />
+					<HabitActionMenu habit={habit} onUnauthorized={onUnauthorized} />
+				</div>
 			</div>
 		</article>
 	);

--- a/web-app/src/features/habits/habit-card.tsx
+++ b/web-app/src/features/habits/habit-card.tsx
@@ -4,10 +4,15 @@ import { HabitActionMenu } from "./habit-action-menu";
 
 type HabitCardProps = {
 	habit: HomeHabit;
+	archiveFallbackFocusRef?: React.RefObject<HTMLElement | null>;
 	onUnauthorized?: () => void | Promise<void>;
 };
 
-export function HabitCard({ habit, onUnauthorized }: HabitCardProps) {
+export function HabitCard({
+	habit,
+	archiveFallbackFocusRef,
+	onUnauthorized,
+}: HabitCardProps) {
 	return (
 		<article
 			className={`rounded-xl border p-4 shadow-sm ${
@@ -31,7 +36,11 @@ export function HabitCard({ habit, onUnauthorized }: HabitCardProps) {
 				</div>
 				<div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-start">
 					<CompleteButton habit={habit} onUnauthorized={onUnauthorized} />
-					<HabitActionMenu habit={habit} onUnauthorized={onUnauthorized} />
+					<HabitActionMenu
+						archiveFallbackFocusRef={archiveFallbackFocusRef}
+						habit={habit}
+						onUnauthorized={onUnauthorized}
+					/>
 				</div>
 			</div>
 		</article>

--- a/web-app/src/features/habits/habit-card.tsx
+++ b/web-app/src/features/habits/habit-card.tsx
@@ -22,8 +22,8 @@ export function HabitCard({
 			}`}
 			data-completed={habit.isCompletedToday ? "true" : "false"}
 		>
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div className="min-w-0">
+			<div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 gap-y-4 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
+				<div className="col-start-1 row-start-1 min-w-0">
 					<h3 className="flex items-center gap-2 text-base font-semibold text-stone-950">
 						{habit.emoji === "" ? null : (
 							<span aria-hidden="true">{habit.emoji}</span>
@@ -34,8 +34,10 @@ export function HabitCard({
 						現在 {habit.currentStreak}日 ・ 最長 {habit.maxStreak}日
 					</p>
 				</div>
-				<div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-start">
+				<div className="col-span-2 col-start-1 row-start-2 w-full sm:col-span-1 sm:col-start-2 sm:row-start-1 sm:w-auto">
 					<CompleteButton habit={habit} onUnauthorized={onUnauthorized} />
+				</div>
+				<div className="col-start-2 row-start-1 sm:col-start-3">
 					<HabitActionMenu
 						archiveFallbackFocusRef={archiveFallbackFocusRef}
 						habit={habit}

--- a/web-app/src/features/habits/habit-dialog-errors.ts
+++ b/web-app/src/features/habits/habit-dialog-errors.ts
@@ -1,0 +1,37 @@
+import { ApiClientError } from "~/lib/api/client";
+
+export function getEditHabitErrorMessage(error: unknown): string | null {
+	if (!(error instanceof ApiClientError)) {
+		return "通信に失敗しました。接続を確認して再試行してください";
+	}
+	if (error.status === 401) {
+		return null;
+	}
+	if (error.status === null) {
+		return "通信に失敗しました。接続を確認して再試行してください";
+	}
+	switch (error.code) {
+		case "INVALID_REQUEST":
+			return error.message || "リクエスト内容が不正です。";
+		case "HABIT_ARCHIVED":
+			return "この習慣はすでにアーカイブされています";
+		case "HABIT_NOT_FOUND":
+			return "習慣が見つかりません";
+		case "INTERNAL_SERVER_ERROR":
+			return "処理に失敗しました。時間をおいて再試行してください";
+		default:
+			return error.status >= 500
+				? "処理に失敗しました。時間をおいて再試行してください"
+				: "処理に失敗しました。時間をおいて再試行してください";
+	}
+}
+
+export function getArchiveHabitErrorMessage(error: unknown): string | null {
+	if (error instanceof ApiClientError && error.status === 401) {
+		return null;
+	}
+	if (error instanceof ApiClientError && error.code === "HABIT_NOT_FOUND") {
+		return "習慣が見つかりません";
+	}
+	return getEditHabitErrorMessage(error);
+}

--- a/web-app/src/features/habits/habit-list.test.tsx
+++ b/web-app/src/features/habits/habit-list.test.tsx
@@ -66,6 +66,19 @@ describe("TodaySummary と HabitList", () => {
 		expect(
 			screen.getByRole("button", { name: "後の習慣を達成する" }),
 		).toHaveClass("w-full", "sm:w-auto");
+		expect(
+			screen.getByRole("button", { name: "後の習慣を達成する" }).parentElement
+				?.parentElement,
+		).toHaveClass(
+			"col-span-2",
+			"row-start-2",
+			"sm:col-start-2",
+			"sm:row-start-1",
+		);
+		expect(
+			screen.getByRole("button", { name: "後の習慣 の操作メニュー" })
+				.parentElement?.parentElement,
+		).toHaveClass("col-start-2", "row-start-1", "sm:col-start-3");
 		expect(document.querySelector('[data-completed="true"]')).toHaveClass(
 			"bg-emerald-50",
 			"border-emerald-200",

--- a/web-app/src/features/habits/habit-list.test.tsx
+++ b/web-app/src/features/habits/habit-list.test.tsx
@@ -71,8 +71,11 @@ describe("TodaySummary と HabitList", () => {
 			"border-emerald-200",
 		);
 		expect(
-			screen.queryByRole("button", { name: /操作メニュー/ }),
-		).not.toBeInTheDocument();
+			screen.getByRole("button", { name: "後の習慣 の操作メニュー" }),
+		).toBeEnabled();
+		expect(
+			screen.getByRole("button", { name: "先の習慣 の操作メニュー" }),
+		).toBeEnabled();
 	});
 
 	it("対象習慣がない場合は空状態だけを表示し、0 / 0 完了を表示しない", () => {

--- a/web-app/src/features/habits/habit-list.test.tsx
+++ b/web-app/src/features/habits/habit-list.test.tsx
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { PropsWithChildren } from "react";
+import { type PropsWithChildren, StrictMode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
 	HomeDataResponse,
@@ -305,6 +305,58 @@ describe("TodaySummary と HabitList", () => {
 		).toBeDisabled();
 	});
 
+	it("StrictModeのeffect再setup後も成功したstale-state再同期でerrorを消去する", async () => {
+		const user = userEvent.setup();
+		const initialHome = makeHomeData();
+		const synchronization = deferred<Response>();
+		let homeRequestCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			fetchMock.mockImplementation((path: string) => {
+				if (path === "/api/home") {
+					homeRequestCount += 1;
+					return homeRequestCount === 1
+						? Promise.resolve(jsonResponse(initialHome))
+						: synchronization.promise;
+				}
+				return Promise.resolve(
+					jsonResponse(
+						{
+							code: "HABIT_ALREADY_COMPLETED_TODAY",
+							message: "達成済みです。",
+						},
+						409,
+					),
+				);
+			}),
+		);
+		const queryClient = createQueryClient();
+		render(<HomeHabitList />, { wrapper: strictWrapper(queryClient) });
+		await screen.findByText("1 / 3 完了");
+
+		await user.click(screen.getByRole("button", { name: "読書を達成する" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"この習慣は本日すでに達成済みです",
+		);
+		await vi.waitFor(() => expect(homeRequestCount).toBe(2));
+		synchronization.resolve(
+			jsonResponse({
+				...initialHome,
+				habits: [
+					{ ...initialHome.habits[0], isCompletedToday: true },
+					...initialHome.habits.slice(1),
+				],
+			}),
+		);
+
+		await vi.waitFor(() =>
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+		);
+		expect(
+			screen.getByRole("button", { name: "読書を達成済み" }),
+		).toBeDisabled();
+	});
+
 	it("stale-state 再同期GETが失敗するとalertを維持し、再試行を許可する", async () => {
 		const user = userEvent.setup();
 		const initialHome = makeHomeData();
@@ -390,6 +442,18 @@ function wrapper(queryClient: QueryClient) {
 	return function QueryWrapper({ children }: PropsWithChildren) {
 		return (
 			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+function strictWrapper(queryClient: QueryClient) {
+	return function StrictQueryWrapper({ children }: PropsWithChildren) {
+		return (
+			<StrictMode>
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			</StrictMode>
 		);
 	};
 }

--- a/web-app/src/features/habits/habit-list.tsx
+++ b/web-app/src/features/habits/habit-list.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import type { HomeHabit } from "~/features/home/home.contract";
 import { HabitCard } from "./habit-card";
 
@@ -7,22 +8,33 @@ type HabitListProps = {
 };
 
 export function HabitList({ habits, onUnauthorized }: HabitListProps) {
-	if (habits.length === 0) {
-		return (
-			<div className="rounded-xl border border-dashed border-stone-300 bg-stone-50 p-6 text-sm text-stone-600">
-				<p>今日の習慣はまだありません。</p>
-				<p className="mt-1">まずは小さな習慣を1つ追加しましょう。</p>
-			</div>
-		);
-	}
+	const archiveFallbackFocusRef = useRef<HTMLElement>(null);
 
 	return (
-		<ul className="space-y-3" aria-label="今日の習慣一覧">
-			{habits.map((habit) => (
-				<li key={habit.id}>
-					<HabitCard habit={habit} onUnauthorized={onUnauthorized} />
-				</li>
-			))}
-		</ul>
+		<section
+			aria-label="今日の習慣"
+			className="rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700"
+			ref={archiveFallbackFocusRef}
+			tabIndex={-1}
+		>
+			{habits.length === 0 ? (
+				<div className="rounded-xl border border-dashed border-stone-300 bg-stone-50 p-6 text-sm text-stone-600">
+					<p>今日の習慣はまだありません。</p>
+					<p className="mt-1">まずは小さな習慣を1つ追加しましょう。</p>
+				</div>
+			) : (
+				<ul className="space-y-3" aria-label="今日の習慣一覧">
+					{habits.map((habit) => (
+						<li key={habit.id}>
+							<HabitCard
+								archiveFallbackFocusRef={archiveFallbackFocusRef}
+								habit={habit}
+								onUnauthorized={onUnauthorized}
+							/>
+						</li>
+					))}
+				</ul>
+			)}
+		</section>
 	);
 }

--- a/web-app/src/features/habits/habits.mutations.test.tsx
+++ b/web-app/src/features/habits/habits.mutations.test.tsx
@@ -25,7 +25,7 @@ afterEach(() => {
 });
 
 describe("habit mutations", () => {
-	it("create/update/archive成功後にhomeをinvalidateしてrefetchする", async () => {
+	it("createは成功時、update/archiveはDialog close後の明示呼び出しでhomeをrefetchする", async () => {
 		const queryClient = createQueryClient();
 		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
 		const refetchQueries = vi.spyOn(queryClient, "refetchQueries");
@@ -50,6 +50,10 @@ describe("habit mutations", () => {
 		await update.result.current.mutateAsync({ name: "運動" });
 		await archive.result.current.mutateAsync();
 
+		expect(invalidateQueries).toHaveBeenCalledTimes(1);
+		expect(refetchQueries).toHaveBeenCalledTimes(1);
+		await update.result.current.refetchHome();
+		await archive.result.current.refetchHome();
 		expect(invalidateQueries).toHaveBeenCalledTimes(3);
 		expect(refetchQueries).toHaveBeenCalledTimes(3);
 	});

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -123,12 +123,12 @@ function useStaleStateSynchronization(
 	const sequenceRef = useRef(0);
 	const mountedRef = useRef(true);
 
-	useEffect(
-		() => () => {
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
 			mountedRef.current = false;
-		},
-		[],
-	);
+		};
+	}, []);
 
 	const setSynchronizing = useCallback(
 		(value: boolean) => {

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -1,10 +1,18 @@
 import {
 	type QueryClient,
+	queryOptions,
 	useIsMutating,
 	useMutation,
+	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
-import { type RefObject, useCallback, useRef, useState } from "react";
+import {
+	type RefObject,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import type { HomeDataResponse } from "~/features/home/home.contract";
 import {
 	clearHomeCache,
@@ -34,6 +42,10 @@ export function habitMutationPrefix(habitId: string) {
 	return ["habit", habitId] as const;
 }
 
+function habitStaleSynchronizationKey(habitId: string) {
+	return ["habit", habitId, "stale-synchronization"] as const;
+}
+
 export function isHabitMutationPending(
 	queryClient: QueryClient,
 	habitId: string,
@@ -45,6 +57,26 @@ export function isHabitMutationPending(
 
 export function useIsHabitMutationPending(habitId: string): boolean {
 	return useIsMutating({ mutationKey: habitMutationPrefix(habitId) }) > 0;
+}
+
+/** 同一 habit の stale-state 再同期中は、新しい操作を開始させない。 */
+export function useIsHabitMutationSynchronizing(habitId: string): boolean {
+	const queryClient = useQueryClient();
+	const query = useQuery(
+		queryOptions({
+			queryKey: habitStaleSynchronizationKey(habitId),
+			queryFn: () => false,
+			initialData: false,
+			staleTime: Number.POSITIVE_INFINITY,
+			enabled: false,
+		}),
+	);
+	// QueryClientProvider の切替直後にも、対象 client の cache を正として読む。
+	return (
+		query.data ??
+		queryClient.getQueryData<boolean>(habitStaleSynchronizationKey(habitId)) ??
+		false
+	);
 }
 
 function isStaleStateError(error: unknown): boolean {
@@ -81,34 +113,60 @@ function useStaleStateErrorReset(
  * 完了後に HabitCard が再描画されず、表示済みのエラーを消去できないため state も
  * 併用する。直近の mutation error だけが状態を更新する。
  */
-function useStaleStateSynchronization() {
+function useStaleStateSynchronization(
+	queryClient: QueryClient,
+	habitId: string,
+) {
 	const [isSynchronized, setIsSynchronized] = useState(false);
 	const [isSynchronizing, setIsSynchronizing] = useState(false);
 	const synchronizedRef = useRef(false);
 	const sequenceRef = useRef(0);
+	const mountedRef = useRef(true);
+
+	useEffect(
+		() => () => {
+			mountedRef.current = false;
+		},
+		[],
+	);
+
+	const setSynchronizing = useCallback(
+		(value: boolean) => {
+			queryClient.setQueryData(habitStaleSynchronizationKey(habitId), value);
+			if (mountedRef.current) {
+				setIsSynchronizing(value);
+			}
+		},
+		[habitId, queryClient],
+	);
+	const setSynchronized = useCallback((value: boolean) => {
+		if (mountedRef.current) {
+			setIsSynchronized(value);
+		}
+	}, []);
 	const beginSynchronization = useCallback(() => {
 		sequenceRef.current += 1;
 		synchronizedRef.current = false;
-		setIsSynchronized(false);
-		setIsSynchronizing(true);
+		setSynchronized(false);
+		setSynchronizing(true);
 		return sequenceRef.current;
-	}, []);
+	}, [setSynchronizing, setSynchronized]);
 	const completeSynchronization = useCallback(
 		(sequence: number, synchronized: boolean) => {
 			if (sequence === sequenceRef.current) {
 				synchronizedRef.current = synchronized;
-				setIsSynchronized(synchronized);
-				setIsSynchronizing(false);
+				setSynchronized(synchronized);
+				setSynchronizing(false);
 			}
 		},
-		[],
+		[setSynchronizing, setSynchronized],
 	);
 	const clearSynchronization = useCallback(() => {
 		sequenceRef.current += 1;
 		synchronizedRef.current = false;
-		setIsSynchronized(false);
-		setIsSynchronizing(false);
-	}, []);
+		setSynchronized(false);
+		setSynchronizing(false);
+	}, [setSynchronizing, setSynchronized]);
 
 	return {
 		isSynchronized,
@@ -219,7 +277,10 @@ export function useUpdateHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
 	const queryClient = useQueryClient();
-	const staleStateSynchronization = useStaleStateSynchronization();
+	const staleStateSynchronization = useStaleStateSynchronization(
+		queryClient,
+		habitId,
+	);
 	const mutation = useMutation({
 		mutationKey: habitMutationKey(habitId, "update"),
 		mutationFn: (request: UpdateHabitRequest) =>
@@ -256,7 +317,10 @@ export function useArchiveHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
 	const queryClient = useQueryClient();
-	const staleStateSynchronization = useStaleStateSynchronization();
+	const staleStateSynchronization = useStaleStateSynchronization(
+		queryClient,
+		habitId,
+	);
 	const mutation = useMutation({
 		mutationKey: habitMutationKey(habitId, "archive"),
 		mutationFn: () => archiveHabitRequest(habitId),
@@ -292,7 +356,10 @@ export function useCompleteHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
 	const queryClient = useQueryClient();
-	const staleStateSynchronization = useStaleStateSynchronization();
+	const staleStateSynchronization = useStaleStateSynchronization(
+		queryClient,
+		habitId,
+	);
 	const mutation = useMutation({
 		mutationKey: habitMutationKey(habitId, "complete"),
 		mutationFn: () => completeHabitRequest(habitId),

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -277,6 +277,10 @@ export function useUpdateHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
 	const queryClient = useQueryClient();
+	const refetchHome = useCallback(
+		() => invalidateAndRefetchHome(queryClient),
+		[queryClient],
+	);
 	const staleStateSynchronization = useStaleStateSynchronization(
 		queryClient,
 		habitId,
@@ -288,7 +292,6 @@ export function useUpdateHabitMutation(
 		onMutate: () => {
 			staleStateSynchronization.clearSynchronization();
 		},
-		onSuccess: () => invalidateAndRefetchHome(queryClient),
 		onError: (error) => {
 			synchronizeStaleStateError(
 				queryClient,
@@ -306,6 +309,7 @@ export function useUpdateHabitMutation(
 	);
 	return {
 		...mutation,
+		refetchHome,
 		resetStaleStateError,
 		isStaleStateSynchronized: staleStateSynchronization.isSynchronized,
 		isStaleStateSynchronizing: staleStateSynchronization.isSynchronizing,
@@ -317,6 +321,10 @@ export function useArchiveHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
 	const queryClient = useQueryClient();
+	const refetchHome = useCallback(
+		() => invalidateAndRefetchHome(queryClient),
+		[queryClient],
+	);
 	const staleStateSynchronization = useStaleStateSynchronization(
 		queryClient,
 		habitId,
@@ -327,7 +335,6 @@ export function useArchiveHabitMutation(
 		onMutate: () => {
 			staleStateSynchronization.clearSynchronization();
 		},
-		onSuccess: () => invalidateAndRefetchHome(queryClient),
 		onError: (error) => {
 			synchronizeStaleStateError(
 				queryClient,
@@ -345,6 +352,7 @@ export function useArchiveHabitMutation(
 	);
 	return {
 		...mutation,
+		refetchHome,
 		resetStaleStateError,
 		isStaleStateSynchronized: staleStateSynchronization.isSynchronized,
 		isStaleStateSynchronizing: staleStateSynchronization.isSynchronizing,


### PR DESCRIPTION
## 概要

習慣カードから既存習慣を編集・アーカイブできるRadix Dropdown MenuとDialogを実装し、既存mutation基盤へ接続しました。

Closes #81

## 変更内容

- `@radix-ui/react-dropdown-menu`を追加し、habit名を含むaccessibleな操作メニューを実装
- 編集Dialogで最新name/emojiを初期表示し、追加UIと同じshared validationを再利用
- emoji空文字、name/emoji両field、no-op updateをPATCH可能に実装
- 正確なアーカイブ確認文言とidempotent 200成功処理を実装
- update/archive成功時はDialogをcloseして起点へfocusを戻した後にhomeを再取得
- archive後にcardが消える場合は、安定して残る今日の習慣領域へfocusを移動
- 遅いarchive再取得中に別controlへ移したfocusは維持
- mobileでは操作メニューをcard右上、達成ボタンを下段全幅に配置
- pending開始と同一turnを含む二重submit・Esc・outside closeを抑止し、focusをmenu triggerへ復帰
- stale-state再同期状態を同一habitの全操作へ共有し、complete/edit/archiveを相互排他
- stale errorは同期中保持し、自身のhome GET成功後にDialog-local errorも消去
- TanStack StartのStrictMode effect再実行後もstale同期完了をUIへ反映
- 別habitの操作は独立して継続可能
- 401をglobal authへ委譲し、validation/stale/500/networkをDialog内表示

## 確認

- `pnpm test`（20 files / 176 tests）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`

ローカルNode 20ではNode 26 engine warningが出ますが、GitHub CIはrepository指定のNode 26を使用します。
