### PR TITLE
MVPホーム画面を統合

### DIFF
--- a/web-app/src/app.css
+++ b/web-app/src/app.css
@@ -8,7 +8,7 @@
 
 html,
 body {
-	@apply bg-white;
+	@apply bg-stone-50 font-sans text-stone-950 antialiased;
 	color-scheme: light;
 }
 

--- a/web-app/src/features/habits/add-habit-dialog.test.tsx
+++ b/web-app/src/features/habits/add-habit-dialog.test.tsx
@@ -124,7 +124,7 @@ describe("AddHabitDialog", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
-	it("trim済みpayloadをPOSTし、成功後にhomeを再取得してから閉じる", async () => {
+	it("trim済みpayloadをPOSTし、Dialog closeとfocus復帰後にhomeを再取得する", async () => {
 		const user = userEvent.setup();
 		let homeRequestCount = 0;
 		let resolveHomeRefetch: ((response: Response) => void) | undefined;
@@ -146,19 +146,20 @@ describe("AddHabitDialog", () => {
 		renderWithClient(<AddHabitDialogWithActiveHome />);
 		await vi.waitFor(() => expect(homeRequestCount).toBe(1));
 		await openDialog(user);
+		const trigger = screen.getByRole("button", {
+			name: "+ タスク追加",
+			hidden: true,
+		});
 		await user.type(screen.getByLabelText("習慣名"), "  読書  ");
 		await user.type(screen.getByLabelText("絵文字（任意）"), "📚");
 		await user.click(screen.getByRole("button", { name: "追加" }));
 
-		await vi.waitFor(() => expect(homeRequestCount).toBe(2));
-		expect(screen.getByRole("dialog")).toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: "追加しています…" }),
-		).toBeDisabled();
-		resolveHomeRefetch?.(jsonResponse(homeData));
 		await vi.waitFor(() =>
 			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
 		);
+		expect(trigger).toHaveFocus();
+		await vi.waitFor(() => expect(homeRequestCount).toBe(2));
+		resolveHomeRefetch?.(jsonResponse(homeData));
 		expect(fetchMock).toHaveBeenCalledWith(
 			"/api/habits",
 			expect.objectContaining({

--- a/web-app/src/features/habits/add-habit-dialog.tsx
+++ b/web-app/src/features/habits/add-habit-dialog.tsx
@@ -66,6 +66,7 @@ export function AddHabitDialog({ onUnauthorized }: AddHabitDialogProps) {
 	const triggerRef = useRef<HTMLButtonElement>(null);
 	const nameInputRef = useRef<HTMLInputElement>(null);
 	const submitInFlight = useRef(false);
+	const refetchHomeAfterClose = useRef(false);
 	const mutation = useCreateHabitMutation({ onUnauthorized });
 	const isPending = mutation.isPending;
 
@@ -121,6 +122,7 @@ export function AddHabitDialog({ onUnauthorized }: AddHabitDialogProps) {
 				name: validatedName.value,
 				emoji: validatedEmoji.value,
 			});
+			refetchHomeAfterClose.current = true;
 			setOpen(false);
 			resetForm();
 		} catch (error) {
@@ -149,6 +151,10 @@ export function AddHabitDialog({ onUnauthorized }: AddHabitDialogProps) {
 					onCloseAutoFocus={(event) => {
 						event.preventDefault();
 						triggerRef.current?.focus();
+						if (refetchHomeAfterClose.current) {
+							refetchHomeAfterClose.current = false;
+							void mutation.refetchHome();
+						}
 					}}
 					onEscapeKeyDown={(event) => {
 						if (isPending || submitInFlight.current) {

--- a/web-app/src/features/habits/habits.mutations.test.tsx
+++ b/web-app/src/features/habits/habits.mutations.test.tsx
@@ -25,7 +25,7 @@ afterEach(() => {
 });
 
 describe("habit mutations", () => {
-	it("createは成功時、update/archiveはDialog close後の明示呼び出しでhomeをrefetchする", async () => {
+	it("create/update/archiveはDialog close後の明示呼び出しでhomeをrefetchする", async () => {
 		const queryClient = createQueryClient();
 		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
 		const refetchQueries = vi.spyOn(queryClient, "refetchQueries");
@@ -50,8 +50,9 @@ describe("habit mutations", () => {
 		await update.result.current.mutateAsync({ name: "運動" });
 		await archive.result.current.mutateAsync();
 
-		expect(invalidateQueries).toHaveBeenCalledTimes(1);
-		expect(refetchQueries).toHaveBeenCalledTimes(1);
+		expect(invalidateQueries).not.toHaveBeenCalled();
+		expect(refetchQueries).not.toHaveBeenCalled();
+		await create.result.current.refetchHome();
 		await update.result.current.refetchHome();
 		await archive.result.current.refetchHome();
 		expect(invalidateQueries).toHaveBeenCalledTimes(3);
@@ -217,10 +218,12 @@ describe("habit mutations", () => {
 			complete.result.current.mutate();
 		});
 		await waitFor(() => expect(resolveComplete).toBeTypeOf("function"));
-		const createExecution = create.result.current.mutateAsync({
-			name: "散歩",
-			emoji: "🚶",
-		});
+		const createExecution = create.result.current
+			.mutateAsync({
+				name: "散歩",
+				emoji: "🚶",
+			})
+			.then(() => create.result.current.refetchHome());
 		await waitFor(() => expect(homeRequestCount).toBe(2));
 		expect(refetchAborted).toBe(false);
 		resolveComplete?.(jsonResponse(completeResponse));

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -262,14 +262,18 @@ export function useCreateHabitMutation(
 	options: { onUnauthorized?: () => void | Promise<void> } = {},
 ) {
 	const queryClient = useQueryClient();
-	return useMutation({
+	const refetchHome = useCallback(
+		() => invalidateAndRefetchHome(queryClient),
+		[queryClient],
+	);
+	const mutation = useMutation({
 		mutationKey: ["habit", "create"],
 		mutationFn: (request: CreateHabitRequest) => createHabitRequest(request),
-		onSuccess: () => invalidateAndRefetchHome(queryClient),
 		onError: (error) => {
 			void synchronizeMutationError(queryClient, error, options.onUnauthorized);
 		},
 	});
+	return { ...mutation, refetchHome };
 }
 
 export function useUpdateHabitMutation(

--- a/web-app/src/features/home/home-header.tsx
+++ b/web-app/src/features/home/home-header.tsx
@@ -1,0 +1,61 @@
+type HomeHeaderProps = {
+	isLoggingOut: boolean;
+	logoutError: string | null;
+	onLogout: () => void;
+	user: {
+		image?: string | null;
+		name?: string | null;
+	};
+};
+
+/** 認証済みホームのためだけの、最小限のアカウントヘッダー。 */
+export function HomeHeader({
+	isLoggingOut,
+	logoutError,
+	onLogout,
+	user,
+}: HomeHeaderProps) {
+	return (
+		<header className="border-b border-stone-200 bg-white">
+			<div className="mx-auto flex min-h-16 w-full max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6 lg:px-8">
+				<a
+					className="rounded text-lg font-semibold tracking-tight text-emerald-900 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-emerald-700"
+					href="#main-content"
+				>
+					Daily Green
+				</a>
+				<div className="flex min-w-0 items-center gap-3">
+					{user.image ? (
+						<img
+							alt=""
+							className="h-9 w-9 shrink-0 rounded-full border border-stone-200 bg-stone-100 object-cover"
+							src={user.image}
+						/>
+					) : null}
+					{user.name ? (
+						<p className="truncate text-sm font-medium text-stone-700">
+							{user.name}
+						</p>
+					) : null}
+					<button
+						aria-busy={isLoggingOut || undefined}
+						className="inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-stone-300 bg-white px-3 py-2 text-sm font-semibold text-stone-800 shadow-sm transition hover:bg-stone-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700 disabled:cursor-not-allowed disabled:bg-stone-100 disabled:text-stone-500"
+						disabled={isLoggingOut}
+						onClick={onLogout}
+						type="button"
+					>
+						{isLoggingOut ? "ログアウトしています…" : "ログアウト"}
+					</button>
+				</div>
+			</div>
+			{logoutError ? (
+				<p
+					className="mx-auto w-full max-w-6xl px-4 pb-3 text-sm text-red-700 sm:px-6 lg:px-8"
+					role="alert"
+				>
+					{logoutError}
+				</p>
+			) : null}
+		</header>
+	);
+}

--- a/web-app/src/features/home/home-main-content.tsx
+++ b/web-app/src/features/home/home-main-content.tsx
@@ -1,0 +1,75 @@
+import { AddHabitDialog } from "~/features/habits/add-habit-dialog";
+import { HabitList } from "~/features/habits/habit-list";
+import { TodaySummary } from "~/features/habits/today-summary";
+import { ActivityLog } from "./activity-log";
+import type { HomeDataResponse } from "./home.contract";
+
+type HomeMainContentProps = {
+	backgroundError: boolean;
+	home: HomeDataResponse;
+	onRetry: () => void;
+	onUnauthorized: () => void | Promise<void>;
+};
+
+/** API から得たホームデータを各 pure UI component へ接続する画面本体。 */
+export function HomeMainContent({
+	backgroundError,
+	home,
+	onRetry,
+	onUnauthorized,
+}: HomeMainContentProps) {
+	return (
+		<main
+			className="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10 lg:px-8"
+			id="main-content"
+		>
+			{backgroundError ? (
+				<div
+					className="mb-6 flex flex-col gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950 sm:flex-row sm:items-center sm:justify-between"
+					role="status"
+				>
+					<p>
+						最新データの取得に失敗しました。表示中の内容は前回取得時のものです。
+					</p>
+					<button
+						className="inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-amber-300 bg-white px-3 py-2 font-semibold text-amber-950 transition hover:bg-amber-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700"
+						onClick={onRetry}
+						type="button"
+					>
+						再読み込み
+					</button>
+				</div>
+			) : null}
+			<section aria-labelledby="activity-log-heading">
+				<div className="mb-4">
+					<h1
+						className="text-xl font-semibold tracking-tight text-stone-950"
+						id="activity-log-heading"
+					>
+						アクティビティログ
+					</h1>
+					<p className="mt-1 text-sm text-stone-600">直近365日の達成状況</p>
+				</div>
+				<div className="rounded-xl border border-stone-200 bg-white p-4 shadow-sm sm:p-5">
+					<ActivityLog entries={home.activityLog} />
+				</div>
+			</section>
+
+			<section aria-labelledby="today-habits-heading" className="mt-10">
+				<div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+					<div>
+						<h2
+							className="text-xl font-semibold tracking-tight text-stone-950"
+							id="today-habits-heading"
+						>
+							今日の習慣
+						</h2>
+						<TodaySummary habits={home.habits} />
+					</div>
+					<AddHabitDialog onUnauthorized={onUnauthorized} />
+				</div>
+				<HabitList habits={home.habits} onUnauthorized={onUnauthorized} />
+			</section>
+		</main>
+	);
+}

--- a/web-app/src/features/home/home-screen.test.tsx
+++ b/web-app/src/features/home/home-screen.test.tsx
@@ -1,0 +1,427 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { homeQueryKey } from "./home.query";
+
+const authMocks = vi.hoisted(() => ({
+	oneTap: vi.fn(),
+	refetchSession: vi.fn(),
+	signOut: vi.fn(),
+	useSession: vi.fn(),
+}));
+
+vi.mock("~/lib/auth-client", () => ({
+	oneTap: authMocks.oneTap,
+	signOut: authMocks.signOut,
+	useSession: authMocks.useSession,
+}));
+
+import { HomeScreen } from "./home-screen";
+import { LoginPanel } from "./login-panel";
+
+const fetchMock = vi.fn();
+let sessionState: ReturnType<typeof makeSessionState>;
+
+beforeEach(() => {
+	sessionState = makeSessionState();
+	authMocks.useSession.mockImplementation(() => sessionState);
+	authMocks.refetchSession.mockResolvedValue(undefined);
+	authMocks.signOut.mockResolvedValue({ data: null, error: null });
+	vi.stubGlobal("fetch", fetchMock.mockResolvedValue(jsonResponse(homeData())));
+});
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe("HomeScreen", () => {
+	it("session確認中はホーム取得を始めず簡潔な読み込み表示を出す", () => {
+		sessionState = makeSessionState({ isPending: true, data: null });
+		renderHome();
+
+		expect(screen.getByText("読み込み中…")).toBeInTheDocument();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("未認証では製品のログイン前表示だけを出してホームAPIを呼ばない", () => {
+		sessionState = makeSessionState({ data: null });
+		renderHome();
+
+		expect(
+			screen.getByRole("heading", { name: /毎日の積み上げを/ }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("毎日の習慣を記録して、積み上げを振り返りましょう。"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/動作確認用|DB サーバー/),
+		).not.toBeInTheDocument();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("session取得失敗時は内部情報を出さず一般的なログインエラーを表示する", () => {
+		sessionState = makeSessionState({ data: null, error: new Error("secret") });
+		renderHome();
+
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"ログインに失敗しました。もう一度お試しください。",
+		);
+		expect(screen.queryByText("secret")).not.toBeInTheDocument();
+	});
+
+	it("Google One Tap成功後はhard reloadせずreactive sessionを再取得する", async () => {
+		const onSessionRefresh = vi.fn().mockResolvedValue(undefined);
+		let onSuccess: (() => void) | undefined;
+		authMocks.oneTap.mockImplementationOnce((options) => {
+			onSuccess = options.fetchOptions?.onSuccess;
+			return Promise.resolve();
+		});
+		render(
+			<LoginPanel
+				googleClientId="test-client-id"
+				onSessionRefresh={onSessionRefresh}
+			/>,
+		);
+
+		await vi.waitFor(() => expect(authMocks.oneTap).toHaveBeenCalledTimes(1));
+		await act(async () => {
+			onSuccess?.();
+		});
+		expect(onSessionRefresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("認証済みでデータ取得中はHeaderを保ったままホームの読み込み表示を出す", async () => {
+		const pending = deferred<Response>();
+		fetchMock.mockReturnValueOnce(pending.promise);
+		renderHome();
+
+		expect(
+			await screen.findByText("今日の習慣を読み込んでいます…"),
+		).toBeInTheDocument();
+		expect(screen.getByText("太郎")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "ログアウト" })).toBeEnabled();
+		pending.resolve(jsonResponse(homeData()));
+	});
+
+	it("Activity Log・今日の習慣・追加Dialog・達成操作を一つのホームに統合する", async () => {
+		const user = userEvent.setup();
+		fetchMock.mockResolvedValueOnce(jsonResponse(homeData()));
+		renderHome();
+
+		expect(
+			await screen.findByRole("heading", { name: "アクティビティログ" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("1 / 2 完了")).toBeInTheDocument();
+		expect(screen.getByText("読書")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "読書を達成する" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getAllByRole("button", { name: "+ タスク追加" }),
+		).toHaveLength(1);
+		expect(screen.queryByText("taro@example.com")).not.toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole("button", { name: "読書 の操作メニュー" }),
+		);
+		await user.click(screen.getByRole("menuitem", { name: "編集" }));
+		expect(
+			await screen.findByRole("dialog", { name: "習慣を編集" }),
+		).toBeInTheDocument();
+		await user.keyboard("{Escape}");
+		await user.click(
+			screen.getByRole("button", { name: "読書 の操作メニュー" }),
+		);
+		await user.click(screen.getByRole("menuitem", { name: "アーカイブ" }));
+		expect(
+			await screen.findByRole("dialog", {
+				name: "「読書」をアーカイブしますか？",
+			}),
+		).toBeInTheDocument();
+		await user.keyboard("{Escape}");
+
+		await user.click(screen.getByRole("button", { name: "+ タスク追加" }));
+		expect(await screen.findByRole("dialog")).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { name: "習慣を追加" }),
+		).toBeInTheDocument();
+	});
+
+	it("習慣が0件ならsummaryを省略し、追加CTAは見出し側の1つだけにする", async () => {
+		fetchMock.mockResolvedValueOnce(jsonResponse(homeData({ habits: [] })));
+		renderHome();
+
+		expect(
+			await screen.findByText("今日の習慣はまだありません。"),
+		).toBeInTheDocument();
+		expect(screen.queryByText("0 / 0 完了")).not.toBeInTheDocument();
+		expect(
+			screen.getAllByRole("button", { name: "+ タスク追加" }),
+		).toHaveLength(1);
+	});
+
+	it("初期取得エラーでは再読み込み導線を表示し、成功後はホームを表示する", async () => {
+		const user = userEvent.setup();
+		fetchMock
+			.mockResolvedValueOnce(
+				jsonResponse(
+					{ code: "INVALID_REQUEST", message: "API internal wording" },
+					400,
+				),
+			)
+			.mockResolvedValueOnce(jsonResponse(homeData()));
+		renderHome();
+
+		expect(
+			await screen.findByRole("heading", {
+				name: "データの取得に失敗しました。",
+			}),
+		).toBeInTheDocument();
+		expect(screen.queryByText("API internal wording")).not.toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "再読み込み" }));
+		expect(await screen.findByText("読書")).toBeInTheDocument();
+	});
+
+	it("background再取得エラーでも表示中のデータを維持して再試行できる", async () => {
+		const user = userEvent.setup();
+		fetchMock
+			.mockResolvedValueOnce(jsonResponse(homeData()))
+			.mockResolvedValueOnce(
+				jsonResponse(
+					{ code: "INVALID_REQUEST", message: "API internal wording" },
+					400,
+				),
+			)
+			.mockResolvedValueOnce(jsonResponse(homeData({ habits: [] })));
+		const { queryClient } = renderHome();
+		await screen.findByText("読書");
+
+		await act(async () => {
+			await queryClient.invalidateQueries({ queryKey: homeQueryKey });
+		});
+
+		expect(await screen.findByRole("status")).toHaveTextContent(
+			"最新データの取得に失敗しました。",
+		);
+		expect(screen.getByText("読書")).toBeInTheDocument();
+		expect(screen.queryByText("API internal wording")).not.toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "再読み込み" }));
+		expect(
+			await screen.findByText("今日の習慣はまだありません。"),
+		).toBeInTheDocument();
+	});
+
+	it("401を受けたらhome cacheを破棄してsessionを再確認し、未認証表示へ戻す", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse(
+				{ code: "UNAUTHORIZED", message: "API internal wording" },
+				401,
+			),
+		);
+		const { queryClient, rerender } = renderHome();
+		authMocks.refetchSession.mockImplementationOnce(async () => {
+			sessionState = makeSessionState({ data: null });
+			rerender(<HomeScreen />);
+		});
+
+		expect(
+			await screen.findByRole("heading", { name: /毎日の積み上げを/ }),
+		).toBeInTheDocument();
+		expect(authMocks.refetchSession).toHaveBeenCalledTimes(1);
+		await vi.waitFor(() =>
+			expect(queryClient.getQueryData(homeQueryKey)).toBeUndefined(),
+		);
+	});
+
+	it("ユーザー切替中は前ユーザーのhomeを表示せず、新しい取得が終わるまで待機する", async () => {
+		const nextHome = deferred<Response>();
+		fetchMock
+			.mockResolvedValueOnce(jsonResponse(homeData()))
+			.mockReturnValueOnce(nextHome.promise);
+		const { rerender } = renderHome();
+		await screen.findByText("読書");
+		sessionState = makeSessionState({
+			data: {
+				session: { id: "session-2", userId: "user-2" },
+				user: {
+					id: "user-2",
+					name: "花子",
+					email: "hanako@example.com",
+					image: null,
+				},
+			},
+		});
+		rerender(<HomeScreen />);
+
+		expect(screen.queryByText("読書")).not.toBeInTheDocument();
+		expect(
+			screen.getByText("今日の習慣を読み込んでいます…"),
+		).toBeInTheDocument();
+		expect(screen.getByText("花子")).toBeInTheDocument();
+		nextHome.resolve(jsonResponse(homeData({ habits: [] })));
+		await screen.findByText("今日の習慣はまだありません。");
+	});
+
+	it("logout中は二重送信を防ぎ、成功時にcacheを破棄してreactive sessionを再確認する", async () => {
+		const user = userEvent.setup();
+		const logout = deferred<{ data: null; error: null }>();
+		authMocks.signOut.mockReturnValueOnce(logout.promise);
+		fetchMock.mockResolvedValueOnce(jsonResponse(homeData()));
+		const { queryClient, rerender } = renderHome();
+		await screen.findByText("読書");
+		const previousHome = queryClient.getQueryData(homeQueryKey);
+		expect(previousHome).toBeDefined();
+		authMocks.refetchSession.mockImplementationOnce(async () => {
+			sessionState = makeSessionState({ data: null });
+			rerender(<HomeScreen />);
+		});
+
+		const button = screen.getByRole("button", { name: "ログアウト" });
+		await user.dblClick(button);
+		expect(authMocks.signOut).toHaveBeenCalledTimes(1);
+		expect(button).toBeDisabled();
+		expect(button).toHaveTextContent("ログアウトしています…");
+
+		await act(async () => {
+			logout.resolve({ data: null, error: null });
+		});
+		expect(
+			await screen.findByRole("heading", { name: /毎日の積み上げを/ }),
+		).toBeInTheDocument();
+		expect(authMocks.refetchSession).toHaveBeenCalledTimes(1);
+		await vi.waitFor(() =>
+			expect(queryClient.getQueryData(homeQueryKey)).toBeUndefined(),
+		);
+	});
+
+	it("logout失敗時は一般エラーを表示し、sessionとhome cacheを維持して再試行できる", async () => {
+		const user = userEvent.setup();
+		authMocks.signOut.mockResolvedValueOnce({
+			data: null,
+			error: new Error("internal logout detail"),
+		});
+		const { queryClient } = renderHome();
+		await screen.findByText("読書");
+
+		await user.click(screen.getByRole("button", { name: "ログアウト" }));
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"ログアウトに失敗しました。もう一度お試しください。",
+		);
+		expect(
+			screen.queryByText("internal logout detail"),
+		).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "ログアウト" })).toBeEnabled();
+		expect(screen.getByText("読書")).toBeInTheDocument();
+		expect(queryClient.getQueryData(homeQueryKey)).toBeDefined();
+		expect(authMocks.refetchSession).not.toHaveBeenCalled();
+	});
+});
+
+function renderHome() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+		},
+	});
+	const result = render(<HomeScreen />, { wrapper: wrapper(queryClient) });
+	return { ...result, queryClient };
+}
+
+function wrapper(queryClient: QueryClient) {
+	return function QueryWrapper({ children }: PropsWithChildren) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+function makeSessionState(
+	overrides: Partial<{
+		data: {
+			session: { id: string; userId: string };
+			user: {
+				id: string;
+				name: string;
+				email: string;
+				image: string | null;
+			};
+		} | null;
+		error: Error | null;
+		isPending: boolean;
+	}> = {},
+) {
+	return {
+		data: {
+			session: { id: "session-1", userId: "user-1" },
+			user: {
+				id: "user-1",
+				name: "太郎",
+				email: "taro@example.com",
+				image: "https://example.com/avatar.png",
+			},
+		},
+		error: null,
+		isPending: false,
+		isRefetching: false,
+		refetch: authMocks.refetchSession,
+		...overrides,
+	};
+}
+
+function homeData(
+	overrides: Partial<{
+		habits: Array<{
+			id: string;
+			name: string;
+			emoji: string;
+			currentStreak: number;
+			maxStreak: number;
+			isCompletedToday: boolean;
+		}>;
+	}> = {},
+) {
+	return {
+		habits: [
+			{
+				id: "reading",
+				name: "読書",
+				emoji: "📚",
+				currentStreak: 2,
+				maxStreak: 5,
+				isCompletedToday: false,
+			},
+			{
+				id: "walk",
+				name: "散歩",
+				emoji: "",
+				currentStreak: 4,
+				maxStreak: 4,
+				isCompletedToday: true,
+			},
+		],
+		activityLog: [
+			{ date: "2026-08-07", completionRate: 0.5 },
+			{ date: "2026-08-08", completionRate: null },
+		],
+		...overrides,
+	};
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function deferred<T>() {
+	let resolve: (value: T) => void = () => undefined;
+	const promise = new Promise<T>((promiseResolve) => {
+		resolve = promiseResolve;
+	});
+	return { promise, resolve };
+}

--- a/web-app/src/features/home/home-screen.tsx
+++ b/web-app/src/features/home/home-screen.tsx
@@ -1,0 +1,148 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useRef, useState } from "react";
+import { signOut, useSession } from "~/lib/auth-client";
+import { useJstMidnightHomeRefresh } from "./home.day-change";
+import { clearHomeCache, useHomeQuery } from "./home.query";
+import { HomeHeader } from "./home-header";
+import { HomeMainContent } from "./home-main-content";
+import { LoginPanel } from "./login-panel";
+
+function LoadingHome() {
+	return (
+		<main
+			className="mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-6xl items-center justify-center px-4 sm:px-6 lg:px-8"
+			id="main-content"
+		>
+			<p aria-live="polite" className="text-sm text-stone-600">
+				今日の習慣を読み込んでいます…
+			</p>
+		</main>
+	);
+}
+
+function InitialHomeError({ onRetry }: { onRetry: () => void }) {
+	return (
+		<main
+			className="mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-6xl items-center justify-center px-4 sm:px-6 lg:px-8"
+			id="main-content"
+		>
+			<section className="w-full max-w-md rounded-xl border border-stone-200 bg-white p-6 text-center shadow-sm">
+				<h1 className="text-lg font-semibold text-stone-950">
+					データの取得に失敗しました。
+				</h1>
+				<p className="mt-2 text-sm leading-6 text-stone-600">
+					時間をおいて、もう一度お試しください。
+				</p>
+				<button
+					className="mt-5 inline-flex cursor-pointer items-center justify-center rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700"
+					onClick={onRetry}
+					type="button"
+				>
+					再読み込み
+				</button>
+			</section>
+		</main>
+	);
+}
+
+/** session と home query を仲介し、各表示 component を接続する薄い画面コンテナ。 */
+export function HomeScreen() {
+	const queryClient = useQueryClient();
+	const {
+		data: session,
+		error: sessionError,
+		isPending: isSessionPending,
+		refetch: refetchSession,
+	} = useSession();
+	const [isLoggingOut, setIsLoggingOut] = useState(false);
+	const [logoutError, setLogoutError] = useState<string | null>(null);
+	const logoutInFlightRef = useRef(false);
+
+	const refreshSession = useCallback(async () => {
+		await refetchSession();
+	}, [refetchSession]);
+	const handleUnauthorized = useCallback(async () => {
+		await refreshSession();
+	}, [refreshSession]);
+	const homeQuery = useHomeQuery({
+		enabled: session != null,
+		userId: session?.user.id,
+		onUnauthorized: handleUnauthorized,
+	});
+
+	// client clock はタイマー予約だけに使い、データ上の「今日」は API を正とする。
+	useJstMidnightHomeRefresh(queryClient, session != null);
+
+	const handleLogout = useCallback(async () => {
+		if (logoutInFlightRef.current) {
+			return;
+		}
+
+		logoutInFlightRef.current = true;
+		setIsLoggingOut(true);
+		setLogoutError(null);
+		try {
+			const result = await signOut();
+			if (result.error) {
+				throw result.error;
+			}
+			await clearHomeCache(queryClient);
+			await refreshSession();
+		} catch {
+			setLogoutError("ログアウトに失敗しました。もう一度お試しください。");
+		} finally {
+			logoutInFlightRef.current = false;
+			setIsLoggingOut(false);
+		}
+	}, [queryClient, refreshSession]);
+
+	if (isSessionPending) {
+		return (
+			<main className="flex min-h-dvh items-center justify-center p-4">
+				<p aria-live="polite" className="text-sm text-stone-600">
+					読み込み中…
+				</p>
+			</main>
+		);
+	}
+
+	if (session == null) {
+		return (
+			<LoginPanel
+				initialError={sessionError != null}
+				onSessionRefresh={refreshSession}
+			/>
+		);
+	}
+
+	return (
+		<div className="min-h-dvh bg-stone-50">
+			<HomeHeader
+				isLoggingOut={isLoggingOut}
+				logoutError={logoutError}
+				onLogout={() => {
+					void handleLogout();
+				}}
+				user={session.user}
+			/>
+			{homeQuery.data ? (
+				<HomeMainContent
+					backgroundError={homeQuery.isError}
+					home={homeQuery.data}
+					onRetry={() => {
+						void homeQuery.refetch();
+					}}
+					onUnauthorized={handleUnauthorized}
+				/>
+			) : homeQuery.isError ? (
+				<InitialHomeError
+					onRetry={() => {
+						void homeQuery.refetch();
+					}}
+				/>
+			) : (
+				<LoadingHome />
+			)}
+		</div>
+	);
+}

--- a/web-app/src/features/home/login-panel.tsx
+++ b/web-app/src/features/home/login-panel.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from "react";
+import { oneTap } from "~/lib/auth-client";
+
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID?.trim() ?? "";
+
+type LoginPanelProps = {
+	googleClientId?: string;
+	initialError?: boolean;
+	onSessionRefresh: () => Promise<void>;
+};
+
+/** 未認証時だけに表示する、Google One Tap のログイン導線。 */
+export function LoginPanel({
+	googleClientId = GOOGLE_CLIENT_ID,
+	initialError = false,
+	onSessionRefresh,
+}: LoginPanelProps) {
+	const buttonRef = useRef<HTMLDivElement>(null);
+	const initializedRef = useRef(false);
+	const [loginError, setLoginError] = useState(
+		initialError ? "ログインに失敗しました。もう一度お試しください。" : null,
+	);
+
+	useEffect(() => {
+		if (initialError) {
+			setLoginError("ログインに失敗しました。もう一度お試しください。");
+		}
+	}, [initialError]);
+
+	useEffect(() => {
+		if (initializedRef.current || !buttonRef.current) {
+			return;
+		}
+		initializedRef.current = true;
+
+		if (googleClientId === "") {
+			setLoginError("ログインに失敗しました。もう一度お試しください。");
+			return;
+		}
+
+		void oneTap({
+			button: {
+				container: buttonRef.current,
+				config: {
+					type: "standard",
+					theme: "outline",
+					size: "large",
+					text: "signin_with",
+					locale: "ja",
+					width: 280,
+				},
+			},
+			fetchOptions: {
+				onSuccess: () => {
+					void onSessionRefresh().catch(() => {
+						setLoginError("ログインに失敗しました。もう一度お試しください。");
+					});
+				},
+				onError: () => {
+					setLoginError("ログインに失敗しました。もう一度お試しください。");
+				},
+			},
+		}).catch(() => {
+			setLoginError("ログインに失敗しました。もう一度お試しください。");
+		});
+	}, [googleClientId, onSessionRefresh]);
+
+	return (
+		<main className="mx-auto flex min-h-dvh w-full max-w-xl items-center px-4 py-12 sm:px-6">
+			<section className="w-full rounded-2xl border border-stone-200 bg-white p-6 shadow-sm sm:p-8">
+				<p className="text-sm font-semibold tracking-wide text-emerald-800">
+					Daily Green
+				</p>
+				<h1 className="mt-2 text-3xl font-semibold tracking-tight text-stone-950">
+					毎日の積み上げを、
+					<br className="sm:hidden" />
+					続けやすく。
+				</h1>
+				<p className="mt-4 text-base leading-7 text-stone-600">
+					毎日の習慣を記録して、積み上げを振り返りましょう。
+				</p>
+				<div className="mt-7 min-h-11" ref={buttonRef} />
+				{loginError ? (
+					<p className="mt-4 text-sm text-red-700" role="alert">
+						{loginError}
+					</p>
+				) : null}
+			</section>
+		</main>
+	);
+}

--- a/web-app/src/routes/__root.tsx
+++ b/web-app/src/routes/__root.tsx
@@ -1,5 +1,4 @@
 import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { ErrorComponentProps } from "@tanstack/react-router";
 import {
 	createRootRouteWithContext,
 	HeadContent,
@@ -48,24 +47,24 @@ function RootComponent() {
 	);
 }
 
-function RootErrorComponent({ error }: ErrorComponentProps) {
-	const details =
-		import.meta.env.DEV && error instanceof Error
-			? error.message
-			: "An unexpected error occurred.";
-	const stack =
-		import.meta.env.DEV && error instanceof Error ? error.stack : null;
-
+function RootErrorComponent() {
 	return (
 		<RootDocument>
-			<main className="container mx-auto p-4 pt-16">
-				<h1>Error</h1>
-				<p>{details}</p>
-				{stack ? (
-					<pre className="w-full overflow-x-auto p-4">
-						<code>{stack}</code>
-					</pre>
-				) : null}
+			<main className="mx-auto flex min-h-dvh w-full max-w-xl items-center px-4 py-12 sm:px-6">
+				<section className="w-full rounded-xl border border-stone-200 bg-white p-6 text-center shadow-sm">
+					<h1 className="text-lg font-semibold text-stone-950">
+						ページを表示できませんでした
+					</h1>
+					<p className="mt-2 text-sm text-stone-600">
+						時間をおいて、もう一度お試しください。
+					</p>
+					<a
+						className="mt-5 inline-flex rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700"
+						href="/"
+					>
+						ホームへ戻る
+					</a>
+				</section>
 			</main>
 		</RootDocument>
 	);
@@ -74,9 +73,21 @@ function RootErrorComponent({ error }: ErrorComponentProps) {
 function NotFoundComponent() {
 	return (
 		<RootDocument>
-			<main className="container mx-auto p-4 pt-16">
-				<h1>404</h1>
-				<p>The requested page could not be found.</p>
+			<main className="mx-auto flex min-h-dvh w-full max-w-xl items-center px-4 py-12 sm:px-6">
+				<section className="w-full rounded-xl border border-stone-200 bg-white p-6 text-center shadow-sm">
+					<h1 className="text-lg font-semibold text-stone-950">
+						ページが見つかりません
+					</h1>
+					<p className="mt-2 text-sm text-stone-600">
+						URLをご確認のうえ、もう一度お試しください。
+					</p>
+					<a
+						className="mt-5 inline-flex rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-700"
+						href="/"
+					>
+						ホームへ戻る
+					</a>
+				</section>
 			</main>
 		</RootDocument>
 	);

--- a/web-app/src/routes/index.tsx
+++ b/web-app/src/routes/index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
-import { oneTap, signOut, useSession } from "~/lib/auth-client";
+import { HomeScreen } from "~/features/home/home-screen";
 
 export const Route = createFileRoute("/")({
 	head: () => ({
@@ -9,105 +8,5 @@ export const Route = createFileRoute("/")({
 			{ name: "description", content: "習慣化アプリ" },
 		],
 	}),
-	component: Home,
+	component: HomeScreen,
 });
-
-function Home() {
-	const { data: session, isPending } = useSession();
-	const buttonRef = useRef<HTMLDivElement>(null);
-	const [loginError, setLoginError] = useState<string | null>(null);
-
-	useEffect(() => {
-		if (isPending || session || !buttonRef.current) {
-			return;
-		}
-
-		if (!import.meta.env.VITE_GOOGLE_CLIENT_ID) {
-			console.error("VITE_GOOGLE_CLIENT_ID is not set");
-			return;
-		}
-
-		void oneTap({
-			button: {
-				container: buttonRef.current,
-				config: {
-					type: "standard",
-					theme: "outline",
-					size: "large",
-					text: "signin_with",
-					locale: "ja",
-					width: 280,
-				},
-			},
-			fetchOptions: {
-				onSuccess: () => {
-					window.location.reload();
-				},
-				onError: () => {
-					setLoginError(
-						"ログインに失敗しました。DB サーバーが起動しているか確認してください。",
-					);
-				},
-			},
-		});
-	}, [session, isPending]);
-
-	const handleLogout = async () => {
-		await signOut({
-			fetchOptions: {
-				onSuccess: () => {
-					window.location.reload();
-				},
-			},
-		});
-	};
-
-	return (
-		<div style={{ padding: "2rem", fontFamily: "sans-serif" }}>
-			<h1>Daily Green 動作確認用ページ</h1>
-
-			{isPending ? (
-				<p>読み込み中...</p>
-			) : session ? (
-				<div
-					style={{
-						border: "1px solid #ccc",
-						padding: "1rem",
-						borderRadius: "8px",
-						maxWidth: "400px",
-					}}
-				>
-					<h2>ログイン成功 🎉</h2>
-					{session.user.image ? (
-						<img
-							src={session.user.image}
-							alt="User Icon"
-							style={{ width: "50px", borderRadius: "50%" }}
-						/>
-					) : null}
-					<p>
-						<strong>名前:</strong> {session.user.name}
-					</p>
-					<p>
-						<strong>メール:</strong> {session.user.email}
-					</p>
-					<button
-						type="button"
-						onClick={handleLogout}
-						className="mt-2 inline-flex cursor-pointer items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:border-gray-400 hover:bg-gray-50 hover:shadow active:scale-[0.98] active:bg-gray-100"
-					>
-						ログアウト
-					</button>
-				</div>
-			) : (
-				<div>
-					<p className="mb-4 text-gray-600">ログインしていません</p>
-					{loginError ? (
-						<p className="mb-4 text-sm text-red-600">{loginError}</p>
-					) : null}
-					<div ref={buttonRef} />
-				</div>
-			)}
-		</div>
-	);
-}


### PR DESCRIPTION
## 概要

デモ用トップページを、認証状態・Activity Log・今日の習慣を統合した MVP ホーム画面へ置き換えます。

## 変更内容

- 未認証・認証確認中・認証済みの各表示を整理し、Google One Tap 成功後とログアウト後を reactive session 再取得で接続
- 認証済みの場合のみホーム API を取得し、ログアウト・401・ユーザー切替時にホームキャッシュを破棄
- Activity Log、今日の完了数、追加・編集・アーカイブ・達成操作を単一カラムのホームへ統合
- 初期取得失敗と background 再取得失敗を分け、表示中データを維持した再試行導線を追加
- モバイルで Activity Log を最新日側に寄せ、操作メニュー右上・達成ボタン全幅となるレスポンシブ表示を実装
- 内部エラー詳細やデモ文言を画面から除去し、ルートエラー／404 を一般向け表示へ変更
- 追加成功時も Dialog close・フォーカス復帰後にホームを再取得するよう統一

## 確認

- `pnpm test`（21 files / 189 tests）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run build`
- Browser QA: 1440×900 / 390×844、ログイン前・認証済みホーム、Activity Log 横スクロール、追加／編集 Dialog とフォーカス復帰

Closes #36
