### PR TITLE
MVPホーム画面の最終hardening

### DIFF
--- a/web-app/src/features/habits/habits.mutations.test.tsx
+++ b/web-app/src/features/habits/habits.mutations.test.tsx
@@ -104,22 +104,31 @@ describe("habit mutations", () => {
 		expect(updated?.habits).toEqual([
 			{
 				...original.habits[0],
-				isCompletedToday: true,
-				currentStreak: 2,
-				maxStreak: 4,
+				...completeResponse.habit,
 			},
 			original.habits[1],
 		]);
 		expect(updated?.activityLog).toBe(original.activityLog);
 	});
 
-	it("complete単独成功は対象3フィールドだけを更新し、追加GETを行わない", async () => {
+	it("別タブの更新が先行したcomplete成功では最新summaryを反映し、追加GETを行わない", async () => {
 		const queryClient = createQueryClient();
+		const staleHome = {
+			...homeData,
+			habits: [
+				{
+					...homeData.habits[0],
+					name: "更新前の読書",
+					emoji: "📙",
+				},
+				...homeData.habits.slice(1),
+			],
+		};
 		vi.stubGlobal(
 			"fetch",
 			fetchMock.mockImplementation((path: string) => {
 				if (path === "/api/home") {
-					return Promise.resolve(jsonResponse(homeData));
+					return Promise.resolve(jsonResponse(staleHome));
 				}
 				return Promise.resolve(jsonResponse(completeResponse));
 			}),
@@ -131,7 +140,7 @@ describe("habit mutations", () => {
 		const complete = renderHook(() => useCompleteHabitMutation("habit-1"), {
 			wrapper: wrapper(queryClient),
 		});
-		await waitFor(() => expect(home.result.current.data).toEqual(homeData));
+		await waitFor(() => expect(home.result.current.data).toEqual(staleHome));
 
 		await complete.result.current.mutateAsync();
 
@@ -140,11 +149,12 @@ describe("habit mutations", () => {
 		).toHaveLength(1);
 		await waitFor(() =>
 			expect(home.result.current.data?.habits[0]).toEqual({
-				...homeData.habits[0],
-				isCompletedToday: true,
-				currentStreak: 2,
-				maxStreak: 4,
+				...staleHome.habits[0],
+				...completeResponse.habit,
 			}),
+		);
+		expect(home.result.current.data?.activityLog).toEqual(
+			staleHome.activityLog,
 		);
 	});
 
@@ -646,8 +656,8 @@ const completeResponse = {
 	},
 	habit: {
 		id: "habit-1",
-		name: "サーバー上の名称は使わない",
-		emoji: "✅",
+		name: "更新後の読書",
+		emoji: "📖",
 		currentStreak: 2,
 		maxStreak: 4,
 		isCompletedToday: true,

--- a/web-app/src/features/habits/habits.mutations.ts
+++ b/web-app/src/features/habits/habits.mutations.ts
@@ -238,9 +238,7 @@ function applyCompletedHabit(
 				habit.id === completed.habit.id
 					? {
 							...habit,
-							isCompletedToday: completed.habit.isCompletedToday,
-							currentStreak: completed.habit.currentStreak,
-							maxStreak: completed.habit.maxStreak,
+							...completed.habit,
 						}
 					: habit,
 			),

--- a/web-app/src/features/home/home-main-content.tsx
+++ b/web-app/src/features/home/home-main-content.tsx
@@ -56,7 +56,7 @@ export function HomeMainContent({
 			</section>
 
 			<section aria-labelledby="today-habits-heading" className="mt-10">
-				<div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+				<div className="mb-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
 					<div>
 						<h2
 							className="text-xl font-semibold tracking-tight text-stone-950"

--- a/web-app/src/features/home/home-screen.test.tsx
+++ b/web-app/src/features/home/home-screen.test.tsx
@@ -123,6 +123,20 @@ describe("HomeScreen", () => {
 		expect(
 			screen.getAllByRole("button", { name: "+ タスク追加" }),
 		).toHaveLength(1);
+		const todayHeading = screen.getByRole("heading", { name: "今日の習慣" });
+		const addHabitButton = screen.getByRole("button", { name: "+ タスク追加" });
+		const todaySectionHeader = todayHeading.parentElement?.parentElement;
+		expect(todaySectionHeader).toHaveClass(
+			"flex-col",
+			"items-start",
+			"sm:flex-row",
+			"sm:items-center",
+			"sm:justify-between",
+		);
+		expect(
+			todayHeading.compareDocumentPosition(addHabitButton) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).not.toBe(0);
 		expect(screen.queryByText("taro@example.com")).not.toBeInTheDocument();
 
 		await user.click(


### PR DESCRIPTION
## 概要

MVP ホーム画面の最終横断レビューで見つかった、complete 後のキャッシュ整合性とモバイル配置を hardening します。

## 変更内容

- complete 成功時、レスポンスの `habit` summary 全体を対象カードへ反映
  - 別タブで編集が先行していた場合も、最新の `name` / `emoji` を旧キャッシュへ取り込む
  - Activity Log は変更せず、単独 complete では追加 GET を行わない既存方針を維持
- モバイルで `+ タスク追加` を「今日の習慣」見出し・完了数の下に配置
  - `sm` 以上では従来どおり横並び
- 上記の回帰テストを更新・追加

## 確認

- `pnpm test`（21 files / 189 tests）
- `pnpm run check:ci`
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`
