### PR TITLE
Codexの作業契約と完了ゲートを明確化

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,14 @@
 
 - Closes #
 
+## Goal
+
+<!-- ユーザー/システムから見て何ができれば完了か -->
+
+## Invariants / Non-goals
+
+<!-- 変更後も守る契約、今回あえて変更しない範囲 -->
+
 ## 変更概要
 
 ## 仕様・API・DBへの影響
@@ -9,15 +17,25 @@
 - [ ] 仕様書/API設計を更新した、または影響なし
 - [ ] DBマイグレーションを確認した、または変更なし
 
-## 確認
+## Verification
+
+実際に実行したものだけチェックしてください。
 
 - [ ] `pnpm test`
 - [ ] `pnpm run check:ci`
 - [ ] `pnpm run typecheck`
 - [ ] `pnpm run build`
+- [ ] DB/transaction変更では`db:check`・migration・`test:integration`を確認した、または対象外
+- [ ] production/Docker変更ではrunner imageをbuildした、または対象外
 - [ ] UI変更のスクリーンショットを添付した、またはUI変更なし
 - [ ] キーボード操作・フォーカス・aria属性を確認した、またはUI変更なし
 
+ローカルで実行できなかったrequired checkがある場合は、未実施理由とCIで確認するjobを記載してください。
+
 ## セキュリティ・ロールバック
+
+## 再発防止 / Quality ownership
+
+<!-- 新しい不変条件やreview起点の修正なら、test / DB constraint / lint / CI / architecture / AGENTSのどこへ再発防止を置いたか。不要なら理由。 -->
 
 ## レビューで重点確認してほしい点

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@
 - [ ] `pnpm run check:ci`
 - [ ] `pnpm run typecheck`
 - [ ] `pnpm run build`
-- [ ] DB/transaction変更では`db:check`・migration・`test:integration`を確認した、または対象外
+- [ ] DB/transaction変更ではdisposable/test DBに対して`db:check`・migration・`test:integration`を確認した、または対象外
 - [ ] production/Docker変更ではrunner imageをbuildした、または対象外
 - [ ] UI変更のスクリーンショットを添付した、またはUI変更なし
 - [ ] キーボード操作・フォーカス・aria属性を確認した、またはUI変更なし

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ pnpm run typecheck
 pnpm run build
 ```
 
-For database schema, migration, transaction, or persistence-contract changes, also run the applicable database gates:
+For database schema, migration, transaction, or persistence-contract changes, also run the applicable database gates **only against a disposable/local test PostgreSQL database**. Confirm `DATABASE_URL` is not production before migration or integration-test commands.
 
 ```sh
 cd web-app
@@ -43,7 +43,7 @@ pnpm run db:migrate
 pnpm run test:integration
 ```
 
-After `db:generate`, verify that generated migration/schema output contains only the intended change. If a local PostgreSQL test database is unavailable, state that explicitly and treat the GitHub Actions `migration-test` job as a required completion gate rather than substituting self-review.
+Never run validation migrations or integration tests against production data. After `db:generate`, verify that generated migration/schema output contains only the intended change. If a disposable local PostgreSQL test database is unavailable, state that explicitly and treat the GitHub Actions `migration-test` job as a required completion gate rather than substituting self-review.
 
 For production-runtime or Docker changes, verify the production image in addition to the application build when practical:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,27 +2,76 @@
 
 ## Project Basics
 
-- This repository uses `develop` as the default branch.
+- This repository uses `develop` as the development base branch.
 - The main application lives under `web-app/`.
-- Use pnpm for Node.js package management.
-- Before editing code or tests, read `docs/coding-conventions.md`.
-- Before submitting changes, run the relevant checks from `web-app/`.
+- Use pnpm for Node.js package management and the Node version declared by `web-app/.node-version` / `web-app/package.json`.
+- Before editing code or tests, read `docs/coding-conventions.md` and the task-relevant specification documents.
 
-## Commands
+## Start Every Task
+
+1. Start from the latest `develop`. Create a fresh branch for each pull request; do not reuse a branch from a merged or closed PR.
+2. Inspect the existing implementation, tests, and relevant docs before choosing an implementation approach.
+3. Before substantial implementation, establish a task contract in your working notes:
+   - **Goal**: observable outcome to achieve.
+   - **Invariants**: behavior, API, data, security, or UX contracts that must remain true.
+   - **Non-goals**: nearby work intentionally excluded.
+   - **Acceptance criteria**: externally observable completion conditions.
+   - **Verification**: deterministic tests/checks proving those conditions.
+4. Resolve ambiguity from current specs and code first. Ask for user judgment only when materially different product semantics remain possible.
+
+## Validation
+
+Run the relevant commands from `web-app/`.
+
+For ordinary application changes, the minimum local gate is:
 
 ```sh
 cd web-app
-pnpm install
 pnpm test
 pnpm run check:ci
 pnpm run typecheck
 pnpm run build
 ```
 
+For database schema, migration, transaction, or persistence-contract changes, also run the applicable database gates:
+
+```sh
+cd web-app
+pnpm run db:check
+pnpm run db:generate
+pnpm run db:migrate
+pnpm run test:integration
+```
+
+After `db:generate`, verify that generated migration/schema output contains only the intended change. If a local PostgreSQL test database is unavailable, state that explicitly and treat the GitHub Actions `migration-test` job as a required completion gate rather than substituting self-review.
+
+For production-runtime or Docker changes, verify the production image in addition to the application build when practical:
+
+```sh
+cd web-app
+docker build --target runner --tag dailygreen:ci .
+```
+
+Do not add redundant checks when an existing CI gate already deterministically enforces the same invariant.
+
+## Quality Ownership
+
+When implementation or review reveals a repeatable failure mode, fix both the instance and the cheapest reliable prevention layer:
+
+1. behavioral regression/integration test for observable contracts;
+2. database/schema constraint or migration check for data invariants;
+3. formatter/linter/type/static check for mechanical rules;
+4. `AGENTS.md` for agent decisions that cannot be encoded reliably elsewhere;
+5. architecture boundary when the invalid state should be impossible by construction.
+
+Prefer machine rejection over asking a future agent to remember a review comment. Tests should verify behavior and externally observable contracts, not implementation trivia.
+
 ## Pull Request Rules
 
 - Write pull request titles and descriptions in Japanese.
 - Do not add tool or agent prefixes such as `[codex]` to pull request titles.
+- Keep one coherent concern per PR; split unrelated refactors or policy changes.
+- In the PR body, state the goal, important invariants/non-goals, and the verification actually performed. Do not claim a local check ran when it only ran in CI.
 
 ## TanStack Guidance
 


### PR DESCRIPTION
## 概要

現行CIはlint/typecheck、unit test、PostgreSQL migration/integration、build/Dockerまで十分に強いため、チェックを増やすのではなくCodexが変更種別に応じて既存ゲートへ確実に到達できるよう`AGENTS.md`とPRテンプレートを整理します。

## 変更内容

- 最新`develop`からPRごとにfresh branchを作り、closed/merged PRのbranchを再利用しないルールを追加
- substantial taskでGoal / Invariants / Non-goals / Acceptance criteria / Verificationを先に定める作業契約を追加
- 通常変更、DB/transaction変更、production/Docker変更ごとの検証コマンドを明示
- DB migration/integrationのローカル検証はdisposable/test PostgreSQLだけに限定し、`DATABASE_URL`がproductionでないことを事前確認する安全条件を追加
- ローカルtest DBがない場合にintegration testを実施済みと誤認せず、GitHub Actions `migration-test`をrequired completion gateとして扱う方針を追加
- 再現可能なレビュー指摘をtest / DB constraint / static check / AGENTS / architectureへ還元する品質ループを追加
- PRテンプレートへGoal / Invariants・Non-goals / Verification / 再発防止を追加し、実装時の作業契約をレビューへ引き継ぐ
- 既存のTanStack Intent方針、PR日本語ルール、UI/accessibility確認項目は維持

## 狙い

Codexの自己レビューを強化するより、既にある決定論的なCIへタスクを正しく接続し、人間が毎回「この変更なら何を確認するか」をルーティングする負担を減らします。

## 検証

ローカルcloneは実行環境のネットワーク制約で行えなかったため、PR Actionsを正としました。最新headのCIはunit test、lint/typecheck、migration/integration、application build、production Docker image buildを含めすべて成功しています。
