### PR TITLE
Push通知設定とSubscriptionのDBスキーマを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,16 @@ jobs:
           cache-dependency-path: web-app/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm run db:check
-      - run: pnpm run db:generate && git diff --exit-code -- drizzle
+      - run: pnpm run db:generate
+      - uses: actions/upload-artifact@v4
+        with:
+          name: generated-drizzle
+          path: |
+            web-app/drizzle/0004_*.sql
+            web-app/drizzle/meta/0004_snapshot.json
+            web-app/drizzle/meta/_journal.json
+          if-no-files-found: error
+      - run: git diff --exit-code -- drizzle
       - run: pnpm run db:migrate
       - run: pnpm run test:integration
 

--- a/.github/workflows/generate-drizzle-artifact.yml
+++ b/.github/workflows/generate-drizzle-artifact.yml
@@ -1,0 +1,43 @@
+name: Generate Drizzle Artifact
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  NODE_ENV: test
+  DATABASE_URL: postgresql://user:password@localhost:5432/dailygreen_test
+  BETTER_AUTH_SECRET: ci-only-secret-ci-only-secret-123456
+  BETTER_AUTH_URL: http://localhost:5173
+  GOOGLE_CLIENT_ID: test-google-client-id
+  GOOGLE_CLIENT_SECRET: test-google-client-secret
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          package_json_file: web-app/package.json
+          run_install: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: web-app/.node-version
+          cache: pnpm
+          cache-dependency-path: web-app/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+        working-directory: web-app
+      - run: pnpm run db:generate
+        working-directory: web-app
+      - uses: actions/upload-artifact@v4
+        with:
+          name: generated-drizzle
+          path: |
+            web-app/drizzle/0004_*.sql
+            web-app/drizzle/meta/0004_snapshot.json
+            web-app/drizzle/meta/_journal.json
+          if-no-files-found: error

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1,0 +1,208 @@
+# Web Push 通知 v1 / オンプレ構成設計
+
+## 1. 結論
+
+v1では物理サーバーを増やさない。既存の単一オンプレホスト上で、Docker Composeのサービスを分離して実行する。
+
+追加する論理コンポーネントは次の2つである。
+
+- Service Worker / PWA基盤
+- `notification-scheduler` sidecar
+
+PostgreSQL、Webアプリ、Nginx reverse proxyは既存構成を利用する。AWS / GCP等のマネージドサービス、メッセージキュー、Kubernetesは導入しない。
+
+Web Pushの仕様上、アプリサーバーから各ブラウザベンダーのPush ServiceへHTTPS outbound通信は必要になる。Push Service自体をDaily Greenが運用する必要はない。
+
+## 2. 構成
+
+```text
+                         Internet
+                            |
+                      TCP 80 / 443
+                            |
+                  +-------------------+
+                  | reverse-proxy     |
+                  | nginx             |
+                  +---------+---------+
+                            |
+                     Docker network
+                            |
+                   +--------v--------+
+                   | web             |
+                   | TanStack Start  |
+                   +---+----------+--+
+                       |          |
+                       |          +---------------- HTTPS outbound
+                       |                           to Push Services
+                       |
+                +------v-------+
+                | PostgreSQL   |
+                +--------------+
+                       ^
+                       |
+                   DB access
+                       |
+             +---------+----------------+
+             | notification-scheduler   |
+             | no published port        |
+             | no Docker socket mount   |
+             +-------------+------------+
+                           |
+                 HTTP on Docker network
+                           |
+                  internal job endpoint
+```
+
+## 3. Web / scheduler分離
+
+Webプロセス内部の `setInterval` ではなく、scheduler sidecarから60秒ごとに内部job endpointを呼び出す。
+
+理由:
+
+- request処理と時刻起点処理を分離できる
+- schedulerだけをrestart / health monitoringできる
+- Webプロセスの再起動に時刻管理を依存させない
+- Docker socketをmountするscheduler製品を使わずに済む
+- 単一ホストのまま将来workerへ分離しやすい
+
+schedulerは「時刻を刻んで内部HTTP endpointを呼ぶ」以外の業務ロジックを持たない。通知対象判定・DB transaction・Web Push送信はWebアプリのserver-only serviceへ置く。
+
+## 4. Docker network
+
+- `reverse-proxy`, `web`, `db`, `notification-scheduler` を同じアプリ用bridge networkへ接続する
+- 外部公開portはreverse proxyの80/443だけを基本とする
+- schedulerはportをpublishしない
+- schedulerからはDocker DNS名 `web` で内部job endpointを呼ぶ
+- PostgreSQLを本番でホストへ公開する必要はない
+- schedulerへDocker socketをmountしない
+
+## 5. 内部job endpoint
+
+例: `POST /internal/jobs/push-dispatch`
+
+- Nginxでは外部から到達できないlocationとして扱う
+- さらに `INTERNAL_JOB_TOKEN` をheaderで検証する
+- token比較は固定長化またはtiming-safe比較を用いる
+- request bodyは不要
+- job全体はPostgreSQL advisory lockでsingleton化し、二重schedulerや手動実行が重なっても同時dispatchしない
+
+## 6. 通知対象判定
+
+Daily Greenの日付仕様に合わせてJST固定とする。
+
+1. 現在のJST日付・時刻を取得
+2. `notification_setting.enabled = true`
+3. `notifyAt <= 現在時刻`
+4. `lastNotifiedDate != 今日`
+5. active habitが1件以上
+6. 今日の `daily_record` が存在しないactive habitが1件以上
+
+条件を満たしたユーザーだけ送信対象とする。
+
+送信対象確定時にtransaction内で `lastNotifiedDate = 今日` を先に更新する。reminderは重複通知の方がユーザー体験を損ねやすいため、v1は厳密な再送保証よりat-most-once寄りとする。
+
+## 7. Web Push
+
+標準Web Push + VAPIDを利用する。
+
+Subscriptionごとに保存する値:
+
+- endpoint
+- p256dh
+- auth
+- expirationTime（提供される場合）
+
+通知payloadは習慣名を含めず、例として次だけを含める。
+
+```json
+{
+  "title": "Daily Green",
+  "body": "今日の習慣があと2個残っています",
+  "url": "/"
+}
+```
+
+Push Serviceが404 / 410を返したSubscriptionは無効とみなしDBから削除する。一時エラーは構造化ログへ残すが、その日の自動再送はv1では行わない。
+
+## 8. DB
+
+### notification_setting
+
+- `userId` text PK / FK
+- `enabled` boolean NOT NULL default false
+- `notifyAt` time NOT NULL default `20:00:00`
+- `lastNotifiedDate` date NULL
+- `createdAt` timestamptz
+- `updatedAt` timestamptz
+
+### push_subscription
+
+- `id` uuid PK
+- `userId` text FK
+- `endpoint` text UNIQUE NOT NULL
+- `p256dh` text NOT NULL
+- `auth` text NOT NULL
+- `expirationTime` timestamptz NULL
+- `createdAt` timestamptz
+- `updatedAt` timestamptz
+
+1ユーザー複数Subscriptionを許可する。
+
+## 9. PWA / Service Worker
+
+- Web App Manifestを `/manifest.webmanifest` で提供
+- `display: standalone`
+- Service Workerを `/sw.js`、scope `/` で登録
+- v1のService WorkerはPush受信とnotification clickだけを責務とする
+- オフラインキャッシュやnavigation interceptionは行わない
+- 通知click時に既存の同一originウィンドウをfocusし、なければ `/` を開く
+- payloadから外部originを開かない
+
+iOS/iPadOSではHome Screenへ追加されたWeb Appから、ボタン操作を起点に通知権限を要求する導線を用意する。
+
+## 10. 秘密値
+
+runtime注入:
+
+- `VAPID_PUBLIC_KEY`
+- `VAPID_PRIVATE_KEY`
+- `VAPID_SUBJECT`
+- `INTERNAL_JOB_TOKEN`
+
+production image build時には渡さない。
+
+VAPID公開鍵だけはブラウザへ公開してよい。秘密鍵とinternal tokenはserver-onlyとする。
+
+## 11. 障害分離
+
+- scheduler停止: 通知だけ停止。Web画面/APIは利用可能
+- Push Service障害: 通知だけ失敗。Web画面/APIは利用可能
+- 個別Subscription失敗: 他Subscriptionの送信を継続
+- DB障害: dispatchを中断し、通知処理だけを理由に不整合な更新を残さない
+- host再起動: Docker restart policyで各サービスを復帰
+
+## 12. 監視
+
+構造化ログへ少なくとも以下を出す。
+
+- dispatch開始/終了
+- candidate users
+- notified users
+- skipped users
+- successful subscriptions
+- failed subscriptions
+- deleted invalid subscriptions
+- duration
+
+scheduler最終成功時刻が一定時間更新されない状態をZabbix等の監視対象にする。
+
+## 13. スケール判断
+
+v1ではqueueを導入しない。次のいずれかが現れたら再検討する。
+
+- 1分周期内にdispatchが終わらない
+- Push送信がWeb APIのCPU/connection poolを圧迫する
+- 複数Webホストへ水平分割する
+- retry / delivery保証がプロダクト要件になる
+
+その段階でworker processとqueueの分離を検討する。

--- a/web-app/public/app-icon.svg
+++ b/web-app/public/app-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Daily Green">
+  <rect width="512" height="512" rx="112" fill="#052e16"/>
+  <path d="M132 324c0-116 72-194 236-204-8 156-82 240-198 240-14 0-27-2-38-5 58-73 118-123 184-151-77 18-139 54-184 120Z" fill="#86efac"/>
+  <path d="M151 374c44-86 105-145 190-178" fill="none" stroke="#dcfce7" stroke-width="22" stroke-linecap="round"/>
+</svg>

--- a/web-app/public/manifest.webmanifest
+++ b/web-app/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "id": "/",
+  "name": "Daily Green",
+  "short_name": "Daily Green",
+  "description": "毎日の習慣を記録し、積み上げをActivity Logで振り返る習慣管理アプリ",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#fafaf9",
+  "theme_color": "#052e16",
+  "lang": "ja",
+  "icons": [
+    {
+      "src": "/app-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/web-app/public/manifest.webmanifest
+++ b/web-app/public/manifest.webmanifest
@@ -1,20 +1,20 @@
 {
-  "id": "/",
-  "name": "Daily Green",
-  "short_name": "Daily Green",
-  "description": "毎日の習慣を記録し、積み上げをActivity Logで振り返る習慣管理アプリ",
-  "start_url": "/",
-  "scope": "/",
-  "display": "standalone",
-  "background_color": "#fafaf9",
-  "theme_color": "#052e16",
-  "lang": "ja",
-  "icons": [
-    {
-      "src": "/app-icon.svg",
-      "sizes": "any",
-      "type": "image/svg+xml",
-      "purpose": "any"
-    }
-  ]
+	"id": "/",
+	"name": "Daily Green",
+	"short_name": "Daily Green",
+	"description": "毎日の習慣を記録し、積み上げをActivity Logで振り返る習慣管理アプリ",
+	"start_url": "/",
+	"scope": "/",
+	"display": "standalone",
+	"background_color": "#fafaf9",
+	"theme_color": "#052e16",
+	"lang": "ja",
+	"icons": [
+		{
+			"src": "/app-icon.svg",
+			"sizes": "any",
+			"type": "image/svg+xml",
+			"purpose": "any"
+		}
+	]
 }

--- a/web-app/public/sw.js
+++ b/web-app/public/sw.js
@@ -1,0 +1,79 @@
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+function parsePushPayload(event) {
+  if (!event.data) {
+    return {};
+  }
+
+  try {
+    return event.data.json();
+  } catch {
+    return { body: event.data.text() };
+  }
+}
+
+function resolveSameOriginUrl(candidate) {
+  try {
+    const target = new URL(candidate || "/", self.location.origin);
+    return target.origin === self.location.origin ? target.href : `${self.location.origin}/`;
+  } catch {
+    return `${self.location.origin}/`;
+  }
+}
+
+self.addEventListener("push", (event) => {
+  const payload = parsePushPayload(event);
+  const title = typeof payload.title === "string" ? payload.title : "Daily Green";
+  const body =
+    typeof payload.body === "string"
+      ? payload.body
+      : "今日の習慣を確認してみましょう";
+  const url = resolveSameOriginUrl(payload.url);
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon: "/app-icon.svg",
+      badge: "/app-icon.svg",
+      tag: "daily-green-reminder",
+      data: { url },
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = resolveSameOriginUrl(event.notification.data?.url);
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then(async (windowClients) => {
+        for (const client of windowClients) {
+          try {
+            if (new URL(client.url).origin === self.location.origin) {
+              if ("navigate" in client) {
+                await client.navigate(url);
+              }
+              if ("focus" in client) {
+                return client.focus();
+              }
+            }
+          } catch {
+            // Ignore stale or malformed client URLs and continue searching.
+          }
+        }
+
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(url);
+        }
+        return undefined;
+      }),
+  );
+});

--- a/web-app/public/sw.js
+++ b/web-app/public/sw.js
@@ -1,79 +1,82 @@
 self.addEventListener("install", () => {
-  self.skipWaiting();
+	self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
-  event.waitUntil(self.clients.claim());
+	event.waitUntil(self.clients.claim());
 });
 
 function parsePushPayload(event) {
-  if (!event.data) {
-    return {};
-  }
+	if (!event.data) {
+		return {};
+	}
 
-  try {
-    return event.data.json();
-  } catch {
-    return { body: event.data.text() };
-  }
+	try {
+		return event.data.json();
+	} catch {
+		return { body: event.data.text() };
+	}
 }
 
 function resolveSameOriginUrl(candidate) {
-  try {
-    const target = new URL(candidate || "/", self.location.origin);
-    return target.origin === self.location.origin ? target.href : `${self.location.origin}/`;
-  } catch {
-    return `${self.location.origin}/`;
-  }
+	try {
+		const target = new URL(candidate || "/", self.location.origin);
+		return target.origin === self.location.origin
+			? target.href
+			: `${self.location.origin}/`;
+	} catch {
+		return `${self.location.origin}/`;
+	}
 }
 
 self.addEventListener("push", (event) => {
-  const payload = parsePushPayload(event);
-  const title = typeof payload.title === "string" ? payload.title : "Daily Green";
-  const body =
-    typeof payload.body === "string"
-      ? payload.body
-      : "今日の習慣を確認してみましょう";
-  const url = resolveSameOriginUrl(payload.url);
+	const payload = parsePushPayload(event);
+	const title =
+		typeof payload.title === "string" ? payload.title : "Daily Green";
+	const body =
+		typeof payload.body === "string"
+			? payload.body
+			: "今日の習慣を確認してみましょう";
+	const url = resolveSameOriginUrl(payload.url);
 
-  event.waitUntil(
-    self.registration.showNotification(title, {
-      body,
-      icon: "/app-icon.svg",
-      badge: "/app-icon.svg",
-      tag: "daily-green-reminder",
-      data: { url },
-    }),
-  );
+	event.waitUntil(
+		self.registration.showNotification(title, {
+			body,
+			icon: "/app-icon.svg",
+			badge: "/app-icon.svg",
+			tag: "daily-green-reminder",
+			data: { url },
+		}),
+	);
 });
 
 self.addEventListener("notificationclick", (event) => {
-  event.notification.close();
-  const url = resolveSameOriginUrl(event.notification.data?.url);
+	event.notification.close();
+	const url = resolveSameOriginUrl(event.notification.data?.url);
 
-  event.waitUntil(
-    self.clients
-      .matchAll({ type: "window", includeUncontrolled: true })
-      .then(async (windowClients) => {
-        for (const client of windowClients) {
-          try {
-            if (new URL(client.url).origin === self.location.origin) {
-              if ("navigate" in client) {
-                await client.navigate(url);
-              }
-              if ("focus" in client) {
-                return client.focus();
-              }
-            }
-          } catch {
-            // Ignore stale or malformed client URLs and continue searching.
-          }
-        }
+	event.waitUntil(
+		self.clients
+			.matchAll({ type: "window", includeUncontrolled: true })
+			.then(async (windowClients) => {
+				for (const client of windowClients) {
+					try {
+						if (new URL(client.url).origin === self.location.origin) {
+							if ("navigate" in client) {
+								await client.navigate(url);
+							}
+							if ("focus" in client) {
+								return client.focus();
+							}
+						}
+					} catch {
+						// Ignore stale or malformed client URLs and continue searching.
+					}
+				}
 
-        if (self.clients.openWindow) {
-          return self.clients.openWindow(url);
-        }
-        return undefined;
-      }),
-  );
+				if (self.clients.openWindow) {
+					return self.clients.openWindow(url);
+				}
+				return undefined;
+			}),
+	);
 });

--- a/web-app/src/db/schema.ts
+++ b/web-app/src/db/schema.ts
@@ -5,6 +5,7 @@ import {
 	integer,
 	pgTable,
 	text,
+	time,
 	timestamp,
 	unique,
 	uuid,
@@ -150,4 +151,43 @@ export const dailyRecord = pgTable(
 	},
 	// 同一日に同じ習慣の記録が重複しないよう、複合ユニーク制約を設定
 	(table) => [unique("habit_date_unique").on(table.habitId, table.date)],
+);
+
+export const notificationSetting = pgTable("notification_setting", {
+	userId: text("userId")
+		.primaryKey()
+		.references(() => user.id, { onDelete: "cascade" }),
+	enabled: boolean("enabled").notNull().default(false),
+	notifyAt: time("notifyAt").notNull().default("20:00:00"),
+	lastNotifiedDate: date("lastNotifiedDate", { mode: "string" }),
+	createdAt: timestamp("createdAt", { mode: "date", withTimezone: true })
+		.notNull()
+		.defaultNow(),
+	updatedAt: timestamp("updatedAt", { mode: "date", withTimezone: true })
+		.notNull()
+		.defaultNow(),
+});
+
+export const pushSubscription = pgTable(
+	"push_subscription",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		userId: text("userId")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		endpoint: text("endpoint").notNull().unique(),
+		p256dh: text("p256dh").notNull(),
+		auth: text("auth").notNull(),
+		expirationTime: timestamp("expirationTime", {
+			mode: "date",
+			withTimezone: true,
+		}),
+		createdAt: timestamp("createdAt", { mode: "date", withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		updatedAt: timestamp("updatedAt", { mode: "date", withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(table) => [index("push_subscription_user_id_idx").on(table.userId)],
 );

--- a/web-app/src/features/push/service-worker-registration.tsx
+++ b/web-app/src/features/push/service-worker-registration.tsx
@@ -11,9 +11,11 @@ export function ServiceWorkerRegistration() {
 			return;
 		}
 
-		void navigator.serviceWorker.register("/sw.js", { scope: "/" }).catch(() => {
-			// Pushは補助機能のため、登録失敗をアプリ本体の障害へ波及させない。
-		});
+		void navigator.serviceWorker
+			.register("/sw.js", { scope: "/" })
+			.catch(() => {
+				// Pushは補助機能のため、登録失敗をアプリ本体の障害へ波及させない。
+			});
 	}, []);
 
 	return null;

--- a/web-app/src/features/push/service-worker-registration.tsx
+++ b/web-app/src/features/push/service-worker-registration.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+
+/** Push通知の前提となるService Workerを安全に登録する。UIは持たない。 */
+export function ServiceWorkerRegistration() {
+	useEffect(() => {
+		if (
+			typeof window === "undefined" ||
+			!window.isSecureContext ||
+			!("serviceWorker" in navigator)
+		) {
+			return;
+		}
+
+		void navigator.serviceWorker.register("/sw.js", { scope: "/" }).catch(() => {
+			// Pushは補助機能のため、登録失敗をアプリ本体の障害へ波及させない。
+		});
+	}, []);
+
+	return null;
+}

--- a/web-app/src/routes/__root.tsx
+++ b/web-app/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import appCss from "~/app.css?url";
+import { ServiceWorkerRegistration } from "~/features/push/service-worker-registration";
 
 export const Route = createRootRouteWithContext<{
 	queryClient: QueryClient;
@@ -15,9 +16,15 @@ export const Route = createRootRouteWithContext<{
 		meta: [
 			{ charSet: "utf-8" },
 			{ name: "viewport", content: "width=device-width, initial-scale=1" },
+			{ name: "theme-color", content: "#052e16" },
+			{ name: "mobile-web-app-capable", content: "yes" },
+			{ name: "apple-mobile-web-app-capable", content: "yes" },
+			{ name: "apple-mobile-web-app-status-bar-style", content: "default" },
 		],
 		links: [
 			{ rel: "stylesheet", href: appCss },
+			{ rel: "manifest", href: "/manifest.webmanifest" },
+			{ rel: "icon", href: "/app-icon.svg", type: "image/svg+xml" },
 			{ rel: "preconnect", href: "https://fonts.googleapis.com" },
 			{
 				rel: "preconnect",
@@ -41,6 +48,7 @@ function RootComponent() {
 	return (
 		<QueryClientProvider client={queryClient}>
 			<RootDocument>
+				<ServiceWorkerRegistration />
 				<Outlet />
 			</RootDocument>
 		</QueryClientProvider>


### PR DESCRIPTION
## 概要

Web Push v1で必要な通知設定とブラウザSubscriptionの永続化スキーマを追加します。

## スキーマ

- `notification_setting`
  - userId PK/FK
  - enabled
  - notifyAt（JST時刻、既定20:00）
  - lastNotifiedDate
  - createdAt / updatedAt
- `push_subscription`
  - id UUID
  - userId FK
  - endpoint UNIQUE
  - p256dh / auth
  - expirationTime
  - createdAt / updatedAt
  - userId index

endpointをグローバルuniqueにすることで、同じブラウザSubscriptionを重複保存しない前提をDBでも保証します。後続APIではログインユーザーによるupsert時にendpointの所有者も現在ユーザーへ更新し、共有端末で旧ユーザーへ通知が漏れないようにします。

## PR構成

#94 のPWA基盤に積み上げるDraft PRです。Drizzle migration生成物まで揃えてCIを通した後にReady化します。`develop` にはマージしません。

Refs #17