### PR TITLE
Push通知scheduler sidecarを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,7 @@ jobs:
       - run: pnpm run build
       - name: Build production Docker image
         run: docker build --target runner --tag dailygreen:ci .
+      - name: Check notification scheduler syntax
+        run: node --check ../notification-scheduler/index.mjs
+      - name: Build notification scheduler Docker image
+        run: docker build --tag dailygreen-notification-scheduler:ci ../notification-scheduler

--- a/notification-scheduler/Dockerfile
+++ b/notification-scheduler/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:26-alpine
+
+WORKDIR /scheduler
+
+COPY index.mjs ./index.mjs
+
+USER node
+
+CMD ["node", "index.mjs"]

--- a/notification-scheduler/index.mjs
+++ b/notification-scheduler/index.mjs
@@ -1,0 +1,116 @@
+const DEFAULT_INTERVAL_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function requiredEnv(name) {
+	const value = process.env[name]?.trim();
+	if (!value) {
+		throw new Error(`${name} is required`);
+	}
+	return value;
+}
+
+function parsePositiveInteger(name, fallback) {
+	const raw = process.env[name]?.trim();
+	if (!raw) {
+		return fallback;
+	}
+	const value = Number(raw);
+	if (!Number.isSafeInteger(value) || value <= 0) {
+		throw new Error(`${name} must be a positive integer`);
+	}
+	return value;
+}
+
+function log(level, event, fields = {}) {
+	console.log(
+		JSON.stringify({
+			timestamp: new Date().toISOString(),
+			level,
+			event,
+			...fields,
+		}),
+	);
+}
+
+const jobUrl = new URL(requiredEnv("INTERNAL_JOB_URL"));
+if (!/^https?:$/.test(jobUrl.protocol)) {
+	throw new Error("INTERNAL_JOB_URL must use http or https");
+}
+
+const jobToken = requiredEnv("INTERNAL_JOB_TOKEN");
+const intervalMs = parsePositiveInteger(
+	"SCHEDULER_INTERVAL_MS",
+	DEFAULT_INTERVAL_MS,
+);
+const timeoutMs = parsePositiveInteger("SCHEDULER_TIMEOUT_MS", DEFAULT_TIMEOUT_MS);
+
+let stopping = false;
+let timer;
+
+async function dispatch() {
+	const startedAt = Date.now();
+	try {
+		const response = await fetch(jobUrl, {
+			method: "POST",
+			headers: {
+				accept: "application/json",
+				"x-internal-job-token": jobToken,
+			},
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+
+		if (!response.ok) {
+			const body = (await response.text()).slice(0, 512);
+			log("error", "push_scheduler_dispatch_failed", {
+				status: response.status,
+				durationMs: Date.now() - startedAt,
+				responseBody: body,
+			});
+			return;
+		}
+
+		log("info", "push_scheduler_dispatch_succeeded", {
+			status: response.status,
+			durationMs: Date.now() - startedAt,
+		});
+	} catch (error) {
+		log("error", "push_scheduler_dispatch_error", {
+			durationMs: Date.now() - startedAt,
+			errorName: error instanceof Error ? error.name : "UnknownError",
+		});
+	}
+}
+
+function scheduleNext() {
+	if (stopping) {
+		return;
+	}
+	timer = setTimeout(async () => {
+		await dispatch();
+		scheduleNext();
+	}, intervalMs);
+}
+
+function shutdown(signal) {
+	if (stopping) {
+		return;
+	}
+	stopping = true;
+	if (timer) {
+		clearTimeout(timer);
+	}
+	log("info", "push_scheduler_stopped", { signal });
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
+log("info", "push_scheduler_started", {
+	jobOrigin: jobUrl.origin,
+	jobPath: jobUrl.pathname,
+	intervalMs,
+	timeoutMs,
+});
+
+await dispatch();
+scheduleNext();


### PR DESCRIPTION
## 概要

オンプレ単一ホストでPush通知jobを定期起動する、最小権限のscheduler sidecarを追加します。

## 変更内容

- `notification-scheduler` のNode.jsスクリプトを追加
- `INTERNAL_JOB_URL` / `INTERNAL_JOB_TOKEN` を必須化
- 既定60秒間隔、30秒timeoutで内部job endpointをPOST
- startup時にも1回dispatch
- JSON構造化ログで成功・HTTP失敗・通信失敗を記録
- response bodyはエラー時も512文字までに制限
- SIGTERM / SIGINTで次回dispatchを停止
- node:26-alpine + non-root `node` userの独立Docker imageを追加
- CIで構文チェックとscheduler image buildを追加

## セキュリティ

- DB資格情報はschedulerに不要
- VAPID秘密鍵もschedulerに不要
- Docker socketをmountしない
- 公開portを必要としない
- token値はログへ出さない

## ブランチ方針

baseは `integration/push-notifications` です。`develop` にはマージしません。

Refs #23