### PR TITLE
オンプレComposeへPush schedulerを配線

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,4 +119,5 @@ jobs:
         working-directory: .
         run: |
           cp web-app/.env.example web-app/.env
+          cp notification-scheduler/.env.example notification-scheduler/.env
           docker compose config --quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,8 @@ jobs:
         run: node --check ../notification-scheduler/index.mjs
       - name: Build notification scheduler Docker image
         run: docker build --tag dailygreen-notification-scheduler:ci ../notification-scheduler
+      - name: Validate Docker Compose
+        working-directory: .
+        run: |
+          cp web-app/.env.example web-app/.env
+          docker compose config --quiet

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@ scripts/
 .idea/
 *.iml
 
+# notification-schedulerの内部job token
+notification-scheduler/.env
+
 # リバースプロキシ用証明書
 nginx/cert/

--- a/compose.yml
+++ b/compose.yml
@@ -24,6 +24,8 @@ services:
       target: dev
     ports:
       - "127.0.0.1:5173:5173"
+    env_file:
+      - ./notification-scheduler/.env
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-user}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-dailygreen}}
     volumes:
@@ -39,7 +41,7 @@ services:
     build:
       context: ./notification-scheduler
     env_file:
-      - ./web-app/.env
+      - ./notification-scheduler/.env
     environment:
       INTERNAL_JOB_URL: http://web:5173/internal/jobs/push-dispatch
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -23,7 +23,7 @@ services:
       context: ./web-app
       target: dev
     ports:
-      - "5173:5173"
+      - "127.0.0.1:5173:5173"
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-user}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-dailygreen}}
     volumes:
@@ -32,6 +32,19 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    networks:
+      - dailygreen-network
+
+  notification-scheduler:
+    build:
+      context: ./notification-scheduler
+    env_file:
+      - ./web-app/.env
+    environment:
+      INTERNAL_JOB_URL: http://web:5173/internal/jobs/push-dispatch
+    depends_on:
+      - web
+    restart: unless-stopped
     networks:
       - dailygreen-network
 
@@ -51,7 +64,6 @@ services:
 networks:
   dailygreen-network:
     driver: bridge
-    
 
 volumes:
   postgres_data:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,6 +14,44 @@
 - 必須環境変数はコンテナ実行時に秘密管理基盤から注入し、サーバーモジュールの初期化時にValibotで検証する
 - CIでは環境変数をDocker buildへ引き渡さずに`runner` targetをbuildし、秘密値なしで成果物を生成できることを確認する
 
+## Web Push通知
+
+### 構成
+
+- v1では既存のオンプレ物理サーバー1台を継続利用し、別ホストやパブリッククラウドのscheduler/queueは追加しない
+- `notification-scheduler` は同一Docker bridge network上で `web` の内部job endpointを60秒間隔で呼ぶだけのsidecarとする
+- schedulerにはDB資格情報、VAPID秘密鍵、Docker socket、公開portを与えない
+- Web Pushの送信処理とDB更新は`web`側に置く
+- `web`から各Push ServiceへのHTTPS outbound通信を許可する
+- reverse proxyは `/internal/jobs/push-dispatch` を外部へproxyせず404を返す。schedulerはDocker networkから`web`へ直接アクセスする
+- ローカル/検証用ComposeではWeb開発ポートを`127.0.0.1:5173`だけへbindし、外部からreverse proxyを迂回しない
+
+### 秘密値
+
+本番では次をruntimeで注入する。
+
+- `VAPID_PUBLIC_KEY`
+- `VAPID_PRIVATE_KEY`
+- `VAPID_SUBJECT`
+- `INTERNAL_JOB_TOKEN`
+
+VAPID key pairは環境ごとに1組を生成し、Subscriptionを維持する間は同じkey pairを継続利用する。`VAPID_PRIVATE_KEY`と`INTERNAL_JOB_TOKEN`はログ、クライアントbundle、`VITE_`環境変数へ出さない。`INTERNAL_JOB_TOKEN`は32文字以上の十分にランダムな値とする。
+
+### 障害時
+
+- scheduler停止時もWebアプリ本体は継続利用できる
+- Push Serviceの障害や個別Subscriptionの失敗をWebリクエスト処理へ波及させない
+- 404/410を返すSubscriptionは無効とみなし削除する
+- dispatchは送信前に`lastNotifiedDate`をclaimするため、v1は重複送信を避けるat-most-once寄りとする。一時的な外部送信失敗を同日に自動再送しない
+- 複数schedulerが誤って起動してもPostgreSQL advisory transaction lockと条件付きclaimで同一時刻のdispatchを直列化する
+
+### 監視
+
+- schedulerの`push_scheduler_dispatch_succeeded`が継続して出ていることを監視する
+- 数分以上成功ログがない場合をZabbix等のアラート対象にする
+- `push_dispatch`の完了ログからcandidate、claimed、success、failure、invalid subscription削除数を収集する
+- failed subscriptionが継続増加する場合はegress、VAPID設定、Push Service応答を調査する
+
 ## PostgreSQLバックアップと復旧
 
 - 本番DBは日次で `pg_dump --format=custom` を取得し、DBとは別の暗号化ストレージへ保存する

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -5,6 +5,10 @@ server {
     listen 80;
     server_name localhost;
 
+    location = /internal/jobs/push-dispatch {
+        return 404;
+    }
+
     location / {
         return 301 https://$host$request_uri;
     }
@@ -19,6 +23,10 @@ server {
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
+
+    location = /internal/jobs/push-dispatch {
+        return 404;
+    }
 
     location / {
         set $upstream http://web:5173;

--- a/notification-scheduler/.env.example
+++ b/notification-scheduler/.env.example
@@ -1,0 +1,3 @@
+# notification-scheduler -> web の内部job認証用。
+# web-app/.env の INTERNAL_JOB_TOKEN と同じ32文字以上のランダム値を設定する。
+INTERNAL_JOB_TOKEN=


### PR DESCRIPTION
## 概要

既存の単一オンプレホスト + Docker Compose構成に `notification-scheduler` を接続し、Push通知を追加サーバーやパブリッククラウドなしで運用できるようにします。

## 変更内容

- `notification-scheduler` serviceを既存Composeへ追加
  - `web` の内部job endpointをDocker networkから直接呼ぶ
  - scheduler専用 `notification-scheduler/.env` から `INTERNAL_JOB_TOKEN` だけを受ける
  - 同じ専用envを`web`にも読み込ませ、内部job tokenだけを共有
  - schedulerへDB/OAuth/VAPID秘密鍵を渡さない
  - 公開port・Docker socketなし
  - `restart: unless-stopped`
- `notification-scheduler/.env.example` を追加し、実ファイルはgitignore
- Web/DBのホスト公開を `127.0.0.1` bindへ限定
- nginxで `/internal/jobs/push-dispatch` をHTTP/HTTPSとも404にし、内部jobを外部公開しない
- Web Pushの単一ホスト運用、秘密値、障害分離、Zabbix監視方針をoperationsへ追記
- CIでscheduler imageとCompose設定を検証

## 構成

`reverse-proxy -> web -> PostgreSQL` の既存構成に、同じbridge network上の `notification-scheduler -> web` を追加するだけです。物理サーバー増設、AWS/GCP、Redis/RabbitMQ等はv1では不要です。

## ブランチ方針

baseは `integration/push-notifications` です。`develop` にはマージしません。

Refs #23