### PR TITLE
Push通知の設定・内部経路をhardening

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -5,7 +5,7 @@ server {
     listen 80;
     server_name localhost;
 
-    location = /internal/jobs/push-dispatch {
+    location ^~ /internal/jobs/ {
         return 404;
     }
 
@@ -24,7 +24,7 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
 
-    location = /internal/jobs/push-dispatch {
+    location ^~ /internal/jobs/ {
         return 404;
     }
 

--- a/web-app/src/features/push/push-notifications.contract.test.ts
+++ b/web-app/src/features/push/push-notifications.contract.test.ts
@@ -74,6 +74,21 @@ describe("Push Subscription入力", () => {
 			}),
 		);
 	});
+
+	it("Date範囲外のexpirationTimeとbase64urlでない鍵を拒否する", () => {
+		expectInvalid(() =>
+			parsePushSubscriptionRequest({
+				...valid,
+				expirationTime: 8_640_000_000_000_001,
+			}),
+		);
+		expectInvalid(() =>
+			parsePushSubscriptionRequest({
+				...valid,
+				keys: { p256dh: "not valid!", auth: "auth-secret" },
+			}),
+		);
+	});
 });
 
 describe("Subscription解除入力", () => {

--- a/web-app/src/features/push/push-notifications.contract.ts
+++ b/web-app/src/features/push/push-notifications.contract.ts
@@ -10,6 +10,8 @@ const subscriptionFields = new Set(["endpoint", "expirationTime", "keys"]);
 const subscriptionKeyFields = new Set(["p256dh", "auth"]);
 const deleteSubscriptionFields = new Set(["endpoint"]);
 const notifyAtPattern = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+const base64UrlPattern = /^[A-Za-z0-9_-]+={0,2}$/;
+const MAX_DATE_EPOCH_MS = 8_640_000_000_000_000;
 
 function invalidRequest(cause?: unknown): never {
 	throw new ApiError("INVALID_REQUEST", undefined, { cause });
@@ -35,7 +37,12 @@ function parseEndpoint(value: unknown): string {
 }
 
 function parseKey(value: unknown): string {
-	if (typeof value !== "string" || value.length === 0 || value.length > 512) {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > 512 ||
+		!base64UrlPattern.test(value)
+	) {
 		return invalidRequest();
 	}
 	return value;
@@ -97,7 +104,8 @@ export function parsePushSubscriptionRequest(
 		expirationTime !== null &&
 		(typeof expirationTime !== "number" ||
 			!Number.isSafeInteger(expirationTime) ||
-			expirationTime <= 0)
+			expirationTime <= 0 ||
+			expirationTime > MAX_DATE_EPOCH_MS)
 	) {
 		return invalidRequest();
 	}

--- a/web-app/src/features/push/push-notifications.service.server.ts
+++ b/web-app/src/features/push/push-notifications.service.server.ts
@@ -19,6 +19,15 @@ function normalizeNotifyAt(value: string): string {
 	return value.slice(0, 5);
 }
 
+function getClientVapidPublicKey(): string | null {
+	return env.VAPID_PUBLIC_KEY &&
+		env.VAPID_PRIVATE_KEY &&
+		env.VAPID_SUBJECT &&
+		env.INTERNAL_JOB_TOKEN
+		? env.VAPID_PUBLIC_KEY
+		: null;
+}
+
 export async function getNotificationSettings(
 	user: AuthenticatedUser,
 ): Promise<NotificationSettingsResponse> {
@@ -34,7 +43,7 @@ export async function getNotificationSettings(
 	return {
 		enabled: setting?.enabled ?? false,
 		notifyAt: setting ? normalizeNotifyAt(setting.notifyAt) : DEFAULT_NOTIFY_AT,
-		vapidPublicKey: env.VAPID_PUBLIC_KEY ?? null,
+		vapidPublicKey: getClientVapidPublicKey(),
 	};
 }
 
@@ -80,7 +89,7 @@ export async function updateNotificationSettings(input: {
 	return {
 		enabled: setting.enabled,
 		notifyAt: normalizeNotifyAt(setting.notifyAt),
-		vapidPublicKey: env.VAPID_PUBLIC_KEY ?? null,
+		vapidPublicKey: getClientVapidPublicKey(),
 	};
 }
 


### PR DESCRIPTION
## 概要

Push通知v1の最終横断レビューで見つかった、設定整合性・Subscription入力・内部job公開範囲をhardeningします。

## 変更内容

- `p256dh` / `auth` をbase64url形式として検証し、異常なSubscription鍵をDBへ保存しない
- `expirationTime` をJavaScript `Date` が扱えるepoch範囲内に制限
- クライアントへVAPID公開鍵を返すのは、公開鍵だけでなくprivate key / subject / internal job tokenまで揃っている場合だけに変更
  - UI上は「設定可能」に見えるのにdispatchできない半設定状態を避ける
- nginxの外部遮断を単一endpoint完全一致から `/internal/jobs/` 名前空間全体へ拡張
  - trailing slashや将来の内部job routeもreverse proxy経由で公開しない
- 上記validationの回帰テストを追加

## ブランチ方針

baseは `integration/push-notifications` です。`develop` にはマージしません。

Refs #17
Refs #23