### PR TITLE
Push runtime設定とsmoke checkを整備

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,26 @@ jobs:
           cp web-app/.env.example web-app/.env
           cp notification-scheduler/.env.example notification-scheduler/.env
           docker compose config --quiet
+      - name: Run Push runtime smoke check
+        working-directory: .
+        run: |
+          node <<'NODE' > web-app/.env
+          const webPush = require('./web-app/node_modules/web-push');
+          const keys = webPush.generateVAPIDKeys();
+          console.log('NODE_ENV=development');
+          console.log('DATABASE_URL=postgresql://user:password@localhost:5432/dailygreen');
+          console.log('BETTER_AUTH_SECRET=ci-only-secret-ci-only-secret-123456');
+          console.log('BETTER_AUTH_URL=http://localhost:5173');
+          console.log('GOOGLE_CLIENT_ID=test-google-client-id');
+          console.log('GOOGLE_CLIENT_SECRET=test-google-client-secret');
+          console.log('VITE_GOOGLE_CLIENT_ID=test-google-client-id');
+          console.log(`VAPID_PUBLIC_KEY=${keys.publicKey}`);
+          console.log(`VAPID_PRIVATE_KEY=${keys.privateKey}`);
+          console.log('VAPID_SUBJECT=mailto:ci@example.com');
+          console.log('INTERNAL_JOB_TOKEN=ci-internal-job-token-12345678901234567890');
+          console.log('APP_VERSION=ci');
+          NODE
+          cat > notification-scheduler/.env <<'EOF'
+          INTERNAL_JOB_TOKEN=ci-internal-job-token-12345678901234567890
+          EOF
+          env -u DATABASE_URL bash scripts/verify-push-runtime.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
         run: docker build --target runner --tag dailygreen:ci .
       - name: Check notification scheduler syntax
         run: node --check ../notification-scheduler/index.mjs
+      - name: Check Push runtime smoke script syntax
+        run: bash -n ../scripts/verify-push-runtime.sh
       - name: Build notification scheduler Docker image
         run: docker build --tag dailygreen-notification-scheduler:ci ../notification-scheduler
       - name: Validate Docker Compose

--- a/compose.yml
+++ b/compose.yml
@@ -25,7 +25,7 @@ services:
     ports:
       - "127.0.0.1:5173:5173"
     env_file:
-      - ./notification-scheduler/.env
+      - ./web-app/.env
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-user}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-dailygreen}}
     volumes:

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -38,20 +38,22 @@ Web Pushの仕様上、アプリサーバーから各ブラウザベンダーの
                 +------v-------+
                 | PostgreSQL   |
                 +--------------+
-                       ^
-                       |
-                   DB access
-                       |
-             +---------+----------------+
+
+             +--------------------------+
              | notification-scheduler   |
              | no published port        |
+             | no DB credentials        |
              | no Docker socket mount   |
              +-------------+------------+
                            |
                  HTTP on Docker network
                            |
                   internal job endpoint
+                           |
+                           +-------------> web
 ```
+
+`notification-scheduler` はPostgreSQLへ直接接続しない。内部HTTP endpointを通じて`web`を起動するだけとし、DBアクセス・通知対象判定・Web Push送信はすべて`web`側へ閉じ込める。
 
 ## 3. Web / scheduler分離
 
@@ -80,7 +82,7 @@ schedulerは「時刻を刻んで内部HTTP endpointを呼ぶ」以外の業務�
 
 例: `POST /internal/jobs/push-dispatch`
 
-- Nginxでは外部から到達できないlocationとして扱う
+- Nginxでは `/internal/jobs/` 名前空間全体を外部から到達できないlocationとして扱う
 - さらに `INTERNAL_JOB_TOKEN` をheaderで検証する
 - token比較は固定長化またはtiming-safe比較を用いる
 - request bodyは不要
@@ -172,6 +174,8 @@ runtime注入:
 production image build時には渡さない。
 
 VAPID公開鍵だけはブラウザへ公開してよい。秘密鍵とinternal tokenはserver-onlyとする。
+
+Composeでは`web-app/.env`を`web`へ、`notification-scheduler/.env`をschedulerへ個別に注入する。scheduler側には`INTERNAL_JOB_TOKEN`以外のWebアプリ秘密値を持たせない。
 
 ## 11. 障害分離
 

--- a/scripts/verify-push-runtime.sh
+++ b/scripts/verify-push-runtime.sh
@@ -58,6 +58,17 @@ if (!token || token.length < 32) {
 console.log("scheduler runtime env: ok");
 NODE
 
+log "webコンテナの依存関係準備を待ちます"
+deps_ready=0
+for _ in $(seq 1 60); do
+  if docker compose exec -T web sh -c 'test -x node_modules/.bin/drizzle-kit' >/dev/null 2>&1; then
+    deps_ready=1
+    break
+  fi
+  sleep 1
+done
+[[ "$deps_ready" -eq 1 ]] || fail "60秒以内にweb依存関係の準備が完了しませんでした"
+
 log "DB migrationを適用します"
 docker compose exec -T web pnpm run db:migrate
 

--- a/scripts/verify-push-runtime.sh
+++ b/scripts/verify-push-runtime.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+log() {
+  printf '[push-smoke] %s\n' "$*"
+}
+
+fail() {
+  printf '[push-smoke] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+for env_file in web-app/.env notification-scheduler/.env; do
+  [[ -f "$env_file" ]] || fail "$env_file がありません"
+done
+
+command -v docker >/dev/null 2>&1 || fail "docker コマンドが見つかりません"
+command -v curl >/dev/null 2>&1 || fail "curl コマンドが見つかりません"
+
+docker compose version >/dev/null 2>&1 || fail "docker compose を利用できません"
+
+log "Compose設定を検証します"
+docker compose config --quiet
+
+log "db / web / notification-scheduler を起動します"
+docker compose up -d --build db web notification-scheduler
+
+log "webコンテナのPush runtime設定を検証します（値は表示しません）"
+docker compose exec -T web node <<'NODE'
+const required = [
+  "VAPID_PUBLIC_KEY",
+  "VAPID_PRIVATE_KEY",
+  "VAPID_SUBJECT",
+  "INTERNAL_JOB_TOKEN",
+];
+const missing = required.filter((name) => !process.env[name]?.trim());
+if (missing.length > 0) {
+  console.error(`missing runtime env: ${missing.join(", ")}`);
+  process.exit(1);
+}
+if ((process.env.INTERNAL_JOB_TOKEN ?? "").length < 32) {
+  console.error("INTERNAL_JOB_TOKEN must be at least 32 characters");
+  process.exit(1);
+}
+console.log("push runtime env: ok");
+NODE
+
+log "schedulerの内部job token設定を検証します（値は表示しません）"
+docker compose exec -T notification-scheduler node <<'NODE'
+const token = process.env.INTERNAL_JOB_TOKEN?.trim();
+if (!token || token.length < 32) {
+  console.error("INTERNAL_JOB_TOKEN is missing or too short");
+  process.exit(1);
+}
+console.log("scheduler runtime env: ok");
+NODE
+
+log "DB migrationを適用します"
+docker compose exec -T web pnpm run db:migrate
+
+log "web readinessを確認します"
+ready=0
+for _ in $(seq 1 30); do
+  if curl --fail --silent --show-error http://127.0.0.1:5173/health/ready >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 2
+done
+[[ "$ready" -eq 1 ]] || fail "60秒以内に /health/ready がreadyになりませんでした"
+
+log "schedulerを再起動し、内部dispatchの成功を確認します"
+docker compose restart notification-scheduler >/dev/null
+scheduler_ok=0
+for _ in $(seq 1 20); do
+  logs="$(docker compose logs --since 45s notification-scheduler 2>&1 || true)"
+  if grep -q 'push_scheduler_dispatch_succeeded' <<<"$logs"; then
+    scheduler_ok=1
+    break
+  fi
+  sleep 2
+done
+
+if [[ "$scheduler_ok" -ne 1 ]]; then
+  docker compose logs --since 2m notification-scheduler >&2 || true
+  fail "schedulerのdispatch成功ログを確認できませんでした"
+fi
+
+log "OK: server-side Push runtime smoke checkに成功しました"
+log "次はブラウザでリマインダーをオンにしてPush Subscriptionを登録できます"

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -7,6 +7,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
 	server: {
+		allowedHosts: ["web"],
 		port: 5173,
 	},
 	plugins: [


### PR DESCRIPTION
## 概要

VAPID / internal job tokenを設定したCompose環境で、webサーバーがserver-only秘密値を確実に`process.env`から参照できるようruntime注入を明示し、実機Push確認前のserver-side smoke checkを1コマンド化します。

## 変更内容

- `web`サービスの`env_file`を`web-app/.env`へ変更
  - VAPID、Better Auth、Google OAuth等のserver runtime設定をwebプロセスへ明示注入
  - scheduler専用`.env`との不要な結合を解消
- `scripts/verify-push-runtime.sh`を追加
  - `.env`存在確認
  - Compose config検証
  - db / web / scheduler build & start
  - 秘密値の存在・長さを値を出さずに検証
  - DB migration適用
  - `/health/ready`確認
  - scheduler再起動後の`push_scheduler_dispatch_succeeded`確認
- smoke script自体をCIで`bash -n`検証
- `docs/push-notifications.md`の構成図を実装境界へ同期
  - schedulerはDB資格情報を持たず、内部HTTPでwebを起動するだけであることを明示
  - `/internal/jobs/`名前空間全体を外部遮断する現行設計へ同期

## 背景

Viteの`.env`読み込みとNodeの`process.env`は同一ではありません。`env.server.ts`はserver秘密値を`process.env`から検証するため、Compose runtimeではDockerの`env_file`として明示注入する方が設定境界として明確です。

## Verification

既存CIでlint/typecheck、unit、migration/integration、production build、Docker image、Compose configに加えてsmoke script構文を確認します。

## ブランチ方針

baseは`integration/push-notifications`です。`develop`にはマージしません。

Refs #17
Refs #23