### PR TITLE
Activity Logのモバイル端切れを修正

### DIFF
--- a/web-app/src/features/home/activity-log.mobile-edge.test.tsx
+++ b/web-app/src/features/home/activity-log.mobile-edge.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ActivityLog } from "./activity-log";
+
+afterEach(() => {
+	cleanup();
+});
+
+describe("ActivityLog mobile edge spacing", () => {
+	it("スクロール内容を実幅で保持し、両端セルのoutline用余白を確保する", () => {
+		render(
+			<ActivityLog
+				entries={[{ date: "2026-08-15", completionRate: 1 }]}
+			/>,
+		);
+
+		expect(screen.getByTestId("activity-log-scroll-area")).toHaveClass(
+			"overflow-x-auto",
+		);
+		expect(screen.getByTestId("activity-log-scroll-content")).toHaveClass(
+			"w-max",
+			"min-w-full",
+			"px-px",
+		);
+	});
+});

--- a/web-app/src/features/home/activity-log.mobile-edge.test.tsx
+++ b/web-app/src/features/home/activity-log.mobile-edge.test.tsx
@@ -9,9 +9,7 @@ afterEach(() => {
 describe("ActivityLog mobile edge spacing", () => {
 	it("スクロール内容を実幅で保持し、両端セルのoutline用余白を確保する", () => {
 		render(
-			<ActivityLog
-				entries={[{ date: "2026-08-15", completionRate: 1 }]}
-			/>,
+			<ActivityLog entries={[{ date: "2026-08-15", completionRate: 1 }]} />,
 		);
 
 		expect(screen.getByTestId("activity-log-scroll-area")).toHaveClass(

--- a/web-app/src/features/home/activity-log.tsx
+++ b/web-app/src/features/home/activity-log.tsx
@@ -247,7 +247,7 @@ export function ActivityLog({ entries }: { entries: ActivityLogEntry[] }) {
 							role="grid"
 						>
 							{WEEKDAY_ROW_IDS.map((rowId, rowIndex) => (
-								/* biome-ignore lint/a11y/useSemanticElements lint/a11y/useFocusableInteractive: 非操作の可視化グリッドで、行自体をTab stopにしない。 */}
+								/* biome-ignore lint/a11y/useSemanticElements lint/a11y/useFocusableInteractive: 非操作の可視化グリッドで、行自体をTab stopにしない。 */
 								<div
 									aria-rowindex={rowIndex + 1}
 									className="grid h-2.5 gap-[3px]"

--- a/web-app/src/features/home/activity-log.tsx
+++ b/web-app/src/features/home/activity-log.tsx
@@ -216,7 +216,10 @@ export function ActivityLog({ entries }: { entries: ActivityLogEntry[] }) {
 					ref={scrollAreaRef}
 					className="min-w-0 flex-1 overflow-x-auto pb-1"
 				>
-					<div className="min-w-[38rem]">
+					<div
+						className="w-max min-w-full px-px"
+						data-testid="activity-log-scroll-content"
+					>
 						<div
 							aria-hidden="true"
 							className="mb-[3px] grid h-2.5 gap-[3px] text-[0.625rem] leading-2.5 text-stone-500"
@@ -244,7 +247,7 @@ export function ActivityLog({ entries }: { entries: ActivityLogEntry[] }) {
 							role="grid"
 						>
 							{WEEKDAY_ROW_IDS.map((rowId, rowIndex) => (
-								/* biome-ignore lint/a11y/useSemanticElements lint/a11y/useFocusableInteractive: 非操作の可視化グリッドで、行自体をTab stopにしない。 */
+								/* biome-ignore lint/a11y/useSemanticElements lint/a11y/useFocusableInteractive: 非操作の可視化グリッドで、行自体をTab stopにしない。 */}
 								<div
 									aria-rowindex={rowIndex + 1}
 									className="grid h-2.5 gap-[3px]"


### PR DESCRIPTION
## 概要

スマホ幅のActivity Logで、横スクロール端にある最左・最右セルのoutlineが見切れる問題を修正します。

## 変更内容

- スクロール内容ラッパーを `w-max min-w-full` に変更し、実際の週グリッド幅をscrollable contentとして保持
- 左右に1pxずつpaddingを確保し、セルの `outline-1` がoverflow端で切れないように調整
- 初回の最新側への自動スクロール処理は変更しない
- background refetch時にユーザーのscroll位置を奪わない既存ロジックは維持
- 端余白の回帰テストを追加

Closes #91